### PR TITLE
Version up maven-surefire-plugin of pom.xml in "15 Build System & Framework Integrations"

### DIFF
--- a/doc/manual/src/chapters/120-build-integrations.md
+++ b/doc/manual/src/chapters/120-build-integrations.md
@@ -154,7 +154,7 @@ Below is a valid `pom.xml` file for working with Geb for testing (with Spock).
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>2.9</version>
+            <version>2.18.1</version>
             <configuration>
               <includes>
                 <include>*Spec.*</include>


### PR DESCRIPTION

When using Japanese Spock in feature method name (example. def
"ログイン画面が表示される" (){} ), there is a problem that surefire
report has "Mojibake(Garbled characters)".
It is due to maven-surefire-plugin problem. I had try to up
maven-surefire-plugin version, so "Mojibake" solved.