### PR TITLE
Fix for GEB-358 at checking for frame page switching

### DIFF
--- a/module/geb-core/src/main/groovy/geb/frame/DefaultFrameSupport.groovy
+++ b/module/geb-core/src/main/groovy/geb/frame/DefaultFrameSupport.groovy
@@ -15,6 +15,7 @@
  */
 package geb.frame
 
+import geb.error.UndefinedAtCheckerException
 import org.openqa.selenium.WebElement
 import org.openqa.selenium.NoSuchFrameException
 import geb.Browser
@@ -54,7 +55,11 @@ class DefaultFrameSupport implements FrameSupport {
         def originalPage = browser.page
         browser.driver.switchTo().frame(frame)
         if (page) {
-            browser.page(page)
+            try {
+                browser.at(page)
+            } catch (UndefinedAtCheckerException e) {
+                browser.page(page)
+            }
         }
         try {
             block.call()

--- a/module/geb-core/src/test/groovy/geb/frame/FrameSupportSpec.groovy
+++ b/module/geb-core/src/test/groovy/geb/frame/FrameSupportSpec.groovy
@@ -152,6 +152,45 @@ class FrameSupportSpec extends BaseFrameSupportSpec {
         page.returnValueOfWithFrameCallForPageContent == 'footer'
         mod.callAllVariantsOfWithFrame() == 3
     }
+
+    def "ensure page context changes to given frame page only if its at verification is true"() {
+        when:
+        withFrame(footer, FrameSupportSpecPageWithPassingAtChecker) {
+            assert page in FrameSupportSpecPageWithPassingAtChecker
+        }
+        then:
+        page in FrameSupportSpecPage
+    }
+
+    def "ensure exception is thrown while changing page context for a given frame page when its at verification fails"() {
+        when:
+        withFrame(footer, FrameSupportSpecPageWithFailingAtChecker) {
+        }
+        then:
+        thrown(AssertionError)
+        page in FrameSupportSpecPage
+    }
+
+    def "ensure page context changes to given frame page instance only if its at verification is true"() {
+        def parameterizedPage = new FrameSupportSpecParametrizedPage(tag: "span")
+        when:
+        withFrame(footer, parameterizedPage) {
+            assert page == parameterizedPage
+        }
+        then:
+        page in FrameSupportSpecPage
+    }
+
+    def "ensure exception is thrown while changing page context for a given frame page instance when its at verification fails"() {
+        def parameterizedPage = new FrameSupportSpecParametrizedPage(tag: "test")
+        when:
+        withFrame(footer, parameterizedPage) {
+
+        }
+        then:
+        thrown(AssertionError)
+        page in FrameSupportSpecPage
+    }
 }
 
 class FrameSupportSpecPage extends Page {
@@ -201,5 +240,17 @@ class FrameSupportSpecParametrizedPage extends Page {
     def getElementText() {
         element.text()
     }
+}
+
+class FrameSupportSpecPageWithPassingAtChecker extends Page {
+    static at = { span.text() == "footer" }
+
+    static content = {
+        span { $("span") }
+    }
+}
+
+class FrameSupportSpecPageWithFailingAtChecker extends Page {
+    static at = { false }
 }
 


### PR DESCRIPTION
Fixed issue in such a way that:
1.Frame Page with at block: Page context will change to given frame page based on its at verification result
2.Frame Page without at block: Simple page context changes to given frame page(No UndefinedAtCheckerException thrown to user)