### PR TITLE
Suport for JUnit4 - screenshot on Error

### DIFF
--- a/module/geb-junit4/src/main/groovy/geb/junit4/ScreenShotOnError.groovy
+++ b/module/geb-junit4/src/main/groovy/geb/junit4/ScreenShotOnError.groovy
@@ -1,0 +1,38 @@
+package geb.junit4
+
+import geb.report.ReporterSupport
+import groovy.util.logging.Log4j
+import org.junit.rules.TestName
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@Log4j
+public class ScreenShotOnError extends TestWatcher{
+
+  @Delegate public GebReportingTest gebReportingTest = new GebReportingTest()
+
+  private TestName reportingTestName
+
+  private Class clazz
+
+  public ScreenShotOnError(Class clazz, TestName gebReportingTestName){
+    this.clazz = clazz
+    this.reportingTestName = gebReportingTestName
+  }
+
+  @Override
+  protected void failed(Throwable e, Description description) {
+    generateReport()
+  }
+
+  @Override
+  protected void starting(Description description) {
+    gebReportingTest.reportGroup clazz
+    gebReportingTest.incrementTestCounterValue()
+  }
+
+  public void generateReport(){
+    browser.report(ReporterSupport.toTestReportLabel(gebReportingTest.getTestCounterValue(), gebReportingTest.instanceTestCounter++,  reportingTestName.methodName, 'error'))
+  }
+
+}

--- a/module/geb-junit4/src/main/groovy/geb/junit4/runners/GebAfter.java
+++ b/module/geb-junit4/src/main/groovy/geb/junit4/runners/GebAfter.java
@@ -1,0 +1,11 @@
+package geb.junit4.runners;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface GebAfter {
+}

--- a/module/geb-junit4/src/main/groovy/geb/junit4/runners/GebBlockJUnit4ClassRunner.groovy
+++ b/module/geb-junit4/src/main/groovy/geb/junit4/runners/GebBlockJUnit4ClassRunner.groovy
@@ -1,0 +1,118 @@
+package geb.junit4.runners
+
+import org.apache.commons.logging.Log
+import org.apache.commons.logging.LogFactory
+import org.junit.internal.runners.model.ReflectiveCallable
+import org.junit.internal.runners.statements.Fail
+import org.junit.internal.runners.statements.RunAfters
+import org.junit.rules.TestRule
+import org.junit.runners.BlockJUnit4ClassRunner
+import org.junit.runners.model.FrameworkMethod
+import org.junit.runners.model.InitializationError
+import org.junit.runners.model.Statement
+import org.springframework.util.ReflectionUtils
+
+import java.lang.reflect.Method
+
+class GebBlockJUnit4ClassRunner extends BlockJUnit4ClassRunner{
+
+  private static final Log logger = LogFactory.getLog(GebBlockJUnit4ClassRunner.class);
+
+  /**
+   * Enhance JUnit execution chain with {@link GebRule}
+   * and  {@link GebAfter}
+   */
+  public GebBlockJUnit4ClassRunner(Class<?> clazz) throws InitializationError {
+    super(clazz);
+  }
+
+  /**
+   * Augments the default SpringJUnit4 behavior
+   * {@link #withRules(FrameworkMethod, Object, Statement, List<TestRule>)
+   *
+   */
+  @Override
+  protected Statement methodBlock(FrameworkMethod frameworkMethod) {
+    Object testInstance;
+    try {
+      testInstance = new ReflectiveCallable() {
+
+        @Override
+        protected Object runReflectiveCall() throws Throwable {
+          return createTest();
+        }
+      }.run();
+    }
+    catch (Throwable ex) {
+      return new Fail(ex);
+    }
+
+    Statement statement = methodInvoker(frameworkMethod, testInstance);
+    statement = possiblyExpectingExceptions(frameworkMethod, testInstance, statement);
+    statement = withBefores(frameworkMethod, testInstance, statement);
+
+    //with GebRules
+    statement = withRules(frameworkMethod, testInstance, statement, getTauliaRules(testInstance));
+
+    //with TauliaAfters
+    statement = withGebAfters(testInstance, statement);
+
+    //with JUnit Afters
+    statement = withAfters(frameworkMethod, testInstance, statement);
+
+    //with JUnit Rules
+    statement = withRules(frameworkMethod, testInstance, statement, getTestRules(testInstance));
+
+    return statement;
+  }
+
+
+
+  private Statement withRules(FrameworkMethod method, Object target, Statement statement, List<TestRule> testRules) {
+    Statement result = statement;
+    result = withMethodRulesReflectively(method, testRules, target, result);
+    result = withTestRulesReflectively(method, testRules, result);
+    return result;
+  }
+
+  /**
+   * Calling BlockJUnit4ClassRunner.withMethodRules() using reflection because the method is private
+   */
+  private Statement withMethodRulesReflectively(FrameworkMethod method, List<TestRule> testRules, Object target, Statement statement) {
+    Method withRulesMethod = ReflectionUtils.findMethod(getClass(), "withMethodRules", FrameworkMethod.class, List.class, Object.class, Statement.class);
+    if (withRulesMethod != null) {
+      ReflectionUtils.makeAccessible(withRulesMethod);
+      statement = (Statement) ReflectionUtils.invokeMethod(withRulesMethod, this, method, testRules,target, statement);
+    }
+    return statement;
+  }
+
+  /**
+   * Calling BlockJUnit4ClassRunner.withTestRules() using reflection because the method is private
+   */
+  private Statement withTestRulesReflectively(FrameworkMethod method, List<TestRule> testRules, Statement statement) {
+    Method withRulesMethod = ReflectionUtils.findMethod(getClass(), "withTestRules", FrameworkMethod.class, List.class, Statement.class);
+    if (withRulesMethod != null) {
+      ReflectionUtils.makeAccessible(withRulesMethod);
+      statement = (Statement) ReflectionUtils.invokeMethod(withRulesMethod, this, method, testRules,statement);
+    }
+    return statement;
+  }
+
+  /**
+   * @param target the test case instance
+   * @return a list of TestRules that should be applied when executing this test
+   */
+  protected List<TestRule> getTauliaRules(Object target) {
+    List<TestRule> result = getTestClass().getAnnotatedMethodValues(target, GebRule.class, TestRule.class);
+    result.addAll(getTestClass().getAnnotatedFieldValues(target, GebRule.class, TestRule.class));
+    return result;
+  }
+
+  protected Statement withGebAfters(Object target, Statement statement) {
+    List<FrameworkMethod> tauliaAfters = getTestClass().getAnnotatedMethods(GebAfter.class);
+    return tauliaAfters.isEmpty() ? statement : new RunAfters(statement, tauliaAfters,
+    target);
+  }
+
+}

--- a/module/geb-junit4/src/main/groovy/geb/junit4/runners/GebBlockJUnit4ClassRunner.groovy
+++ b/module/geb-junit4/src/main/groovy/geb/junit4/runners/GebBlockJUnit4ClassRunner.groovy
@@ -52,9 +52,9 @@ class GebBlockJUnit4ClassRunner extends BlockJUnit4ClassRunner{
     statement = withBefores(frameworkMethod, testInstance, statement);
 
     //with GebRules
-    statement = withRules(frameworkMethod, testInstance, statement, getTauliaRules(testInstance));
+    statement = withRules(frameworkMethod, testInstance, statement, getGebRules(testInstance));
 
-    //with TauliaAfters
+    //with GebAfters
     statement = withGebAfters(testInstance, statement);
 
     //with JUnit Afters
@@ -103,15 +103,15 @@ class GebBlockJUnit4ClassRunner extends BlockJUnit4ClassRunner{
    * @param target the test case instance
    * @return a list of TestRules that should be applied when executing this test
    */
-  protected List<TestRule> getTauliaRules(Object target) {
+  protected List<TestRule> getGebRules(Object target) {
     List<TestRule> result = getTestClass().getAnnotatedMethodValues(target, GebRule.class, TestRule.class);
     result.addAll(getTestClass().getAnnotatedFieldValues(target, GebRule.class, TestRule.class));
     return result;
   }
 
   protected Statement withGebAfters(Object target, Statement statement) {
-    List<FrameworkMethod> tauliaAfters = getTestClass().getAnnotatedMethods(GebAfter.class);
-    return tauliaAfters.isEmpty() ? statement : new RunAfters(statement, tauliaAfters,
+    List<FrameworkMethod> gebAfters = getTestClass().getAnnotatedMethods(GebAfter.class);
+    return gebAfters.isEmpty() ? statement : new RunAfters(statement, gebAfters,
     target);
   }
 

--- a/module/geb-junit4/src/main/groovy/geb/junit4/runners/GebRule.java
+++ b/module/geb-junit4/src/main/groovy/geb/junit4/runners/GebRule.java
@@ -1,0 +1,11 @@
+package geb.junit4.runners;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD})
+public @interface GebRule {
+}

--- a/module/geb-junit4/src/main/groovy/geb/junit4/runners/GebSpringJUnit4ClassRunner.groovy
+++ b/module/geb-junit4/src/main/groovy/geb/junit4/runners/GebSpringJUnit4ClassRunner.groovy
@@ -1,0 +1,118 @@
+package geb.junit4.runners
+
+import org.apache.commons.logging.Log
+import org.apache.commons.logging.LogFactory
+import org.junit.internal.runners.model.ReflectiveCallable
+import org.junit.internal.runners.statements.Fail
+import org.junit.internal.runners.statements.RunAfters
+import org.junit.rules.TestRule
+import org.junit.runners.model.FrameworkMethod
+import org.junit.runners.model.InitializationError
+import org.junit.runners.model.Statement
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
+import org.springframework.util.ReflectionUtils
+
+import java.lang.reflect.Method
+
+class GebSpringJUnit4ClassRunner extends SpringJUnit4ClassRunner{
+
+  private static final Log logger = LogFactory.getLog(GebSpringJUnit4ClassRunner.class);
+
+  /**
+   * Enhance JUnit execution chain with {@link GebRule}
+   * and  {@link GebAfter}
+   */
+  public GebSpringJUnit4ClassRunner(Class<?> clazz) throws InitializationError {
+    super(clazz);
+  }
+
+  /**
+   * Augments the default SpringJUnit4 behavior
+   * {@link #withRules(FrameworkMethod, Object, Statement, List<TestRule>)
+   *
+   */
+  @Override
+  protected Statement methodBlock(FrameworkMethod frameworkMethod) {
+    Object testInstance;
+    try {
+      testInstance = new ReflectiveCallable() {
+
+        @Override
+        protected Object runReflectiveCall() throws Throwable {
+          return createTest();
+        }
+      }.run();
+    }
+    catch (Throwable ex) {
+      return new Fail(ex);
+    }
+
+    Statement statement = methodInvoker(frameworkMethod, testInstance);
+    statement = possiblyExpectingExceptions(frameworkMethod, testInstance, statement);
+    statement = withBefores(frameworkMethod, testInstance, statement);
+
+    //with TauliaRules
+    statement = withRules(frameworkMethod, testInstance, statement, getTauliaRules(testInstance));
+
+    //with TauliaAfters
+    statement = withTauliaAfters(testInstance, statement);
+
+    //with JUnit Afters
+    statement = withAfters(frameworkMethod, testInstance, statement);
+
+    //with JUnit Rules
+    statement = withRules(frameworkMethod, testInstance, statement, getTestRules(testInstance));
+    statement = withPotentialRepeat(frameworkMethod, testInstance, statement);
+    statement = withPotentialTimeout(frameworkMethod, testInstance, statement);
+
+    return statement;
+  }
+
+  private Statement withRules(FrameworkMethod method, Object target, Statement statement, List<TestRule> testRules) {
+    Statement result = statement;
+    result = withMethodRulesReflectively(method, testRules, target, result);
+    result = withTestRulesReflectively(method, testRules, result);
+    return result;
+  }
+
+  /**
+   * Calling BlockJUnit4ClassRunner.withMethodRules() using reflection because the method is private
+   */
+  private Statement withMethodRulesReflectively(FrameworkMethod method, List<TestRule> testRules, Object target, Statement statement) {
+    Method withRulesMethod = ReflectionUtils.findMethod(getClass(), "withMethodRules", FrameworkMethod.class, List.class, Object.class, Statement.class);
+    if (withRulesMethod != null) {
+      ReflectionUtils.makeAccessible(withRulesMethod);
+      statement = (Statement) ReflectionUtils.invokeMethod(withRulesMethod, this, method, testRules,target, statement);
+    }
+    return statement;
+  }
+
+  /**
+   * Calling BlockJUnit4ClassRunner.withTestRules() using reflection because the method is private
+   */
+  private Statement withTestRulesReflectively(FrameworkMethod method, List<TestRule> testRules, Statement statement) {
+    Method withRulesMethod = ReflectionUtils.findMethod(getClass(), "withTestRules", FrameworkMethod.class, List.class, Statement.class);
+    if (withRulesMethod != null) {
+      ReflectionUtils.makeAccessible(withRulesMethod);
+      statement = (Statement) ReflectionUtils.invokeMethod(withRulesMethod, this, method, testRules,statement);
+    }
+    return statement;
+  }
+
+  /**
+   * @param target the test case instance
+   * @return a list of TestRules that should be applied when executing this test
+   */
+  protected List<TestRule> getTauliaRules(Object target) {
+    List<TestRule> result = getTestClass().getAnnotatedMethodValues(target, GebRule.class, TestRule.class);
+    result.addAll(getTestClass().getAnnotatedFieldValues(target, GebRule.class, TestRule.class));
+    return result;
+  }
+
+  protected Statement withTauliaAfters(Object target, Statement statement) {
+    List<FrameworkMethod> tauliaAfters = getTestClass().getAnnotatedMethods(GebAfter.class);
+    return tauliaAfters.isEmpty() ? statement : new RunAfters(statement, tauliaAfters,
+    target);
+  }
+
+}

--- a/module/geb-junit4/src/main/groovy/geb/junit4/runners/GebSpringJUnit4ClassRunner.groovy
+++ b/module/geb-junit4/src/main/groovy/geb/junit4/runners/GebSpringJUnit4ClassRunner.groovy
@@ -51,11 +51,11 @@ class GebSpringJUnit4ClassRunner extends SpringJUnit4ClassRunner{
     statement = possiblyExpectingExceptions(frameworkMethod, testInstance, statement);
     statement = withBefores(frameworkMethod, testInstance, statement);
 
-    //with TauliaRules
-    statement = withRules(frameworkMethod, testInstance, statement, getTauliaRules(testInstance));
+    //with GebRules
+    statement = withRules(frameworkMethod, testInstance, statement, getGebRules(testInstance));
 
-    //with TauliaAfters
-    statement = withTauliaAfters(testInstance, statement);
+    //with withGebAfters
+    statement = withGebAfters(testInstance, statement);
 
     //with JUnit Afters
     statement = withAfters(frameworkMethod, testInstance, statement);
@@ -103,15 +103,15 @@ class GebSpringJUnit4ClassRunner extends SpringJUnit4ClassRunner{
    * @param target the test case instance
    * @return a list of TestRules that should be applied when executing this test
    */
-  protected List<TestRule> getTauliaRules(Object target) {
+  protected List<TestRule> getGebRules(Object target) {
     List<TestRule> result = getTestClass().getAnnotatedMethodValues(target, GebRule.class, TestRule.class);
     result.addAll(getTestClass().getAnnotatedFieldValues(target, GebRule.class, TestRule.class));
     return result;
   }
 
-  protected Statement withTauliaAfters(Object target, Statement statement) {
-    List<FrameworkMethod> tauliaAfters = getTestClass().getAnnotatedMethods(GebAfter.class);
-    return tauliaAfters.isEmpty() ? statement : new RunAfters(statement, tauliaAfters,
+  protected Statement withGebAfters(Object target, Statement statement) {
+    List<FrameworkMethod> gebAfters = getTestClass().getAnnotatedMethods(GebAfter.class);
+    return gebAfters.isEmpty() ? statement : new RunAfters(statement, gebAfters,
     target);
   }
 


### PR DESCRIPTION
@erdi  Kindly asking for review.
I've read that Geb is not currently allowing creating a report on test failure.
I've needed such support for my project and thought that maybe I can share it with you guys so it can be included in the Geb release.

Most of our tests were having a (Logout) in the @After methods so in case of error in smoke test - the logout was clearing the problematic page and screenshot was taken on the Logout from GebReporting class.

Added two new annotations to the JUnit4 rule chain:
@GebRule - support Field and Method annotation. Will be executed Before all @After annotated methods
@GebAfter -support Method annotation. Will be executed Before all @After annotated methods

GebSpringJUnit4ClassRunner - extends SpringJUnit4ClassRunner with support of the above annotation and rule chains
GebBlockJUnit4ClassRunner - extends BlockJUnit4ClassRunner with support of the above annotation and rule chains


Example Usage:
```
@RunWith(GebBlockJUnit4ClassRunner.class)
abstract class PlainGebTestCase extends GebTest {
  @Rule
  public TestName reportingTestName = new TestName()

  @GebRule
  public ScreenShotOnError screenShotOnError = new ScreenShotOnError(getClass(), reportingTestName)
}
```