### PR TITLE
When an option cannot be selected, include the available values in the exception message

### DIFF
--- a/module/geb-core/src/main/groovy/geb/navigator/NonEmptyNavigator.groovy
+++ b/module/geb-core/src/main/groovy/geb/navigator/NonEmptyNavigator.groovy
@@ -749,7 +749,7 @@ class NonEmptyNavigator extends AbstractNavigator {
                 try {
                     select.selectByVisibleText(valueString)
                 } catch (NoSuchElementException e2) {
-                    throw new IllegalArgumentException("couldn't select option with text or value: $valueString")
+                    throw new IllegalArgumentException("couldn't select option with text or value: $valueString, available values: $valueStrings")
                 }
             }
         }

--- a/module/geb-core/src/main/groovy/geb/navigator/NonEmptyNavigator.groovy
+++ b/module/geb-core/src/main/groovy/geb/navigator/NonEmptyNavigator.groovy
@@ -749,7 +749,8 @@ class NonEmptyNavigator extends AbstractNavigator {
                 try {
                     select.selectByVisibleText(valueString)
                 } catch (NoSuchElementException e2) {
-                    throw new IllegalArgumentException("couldn't select option with text or value: $valueString, available values: $valueStrings")
+                    def availableValues = select.options.collect{ it.getAttribute('value') }
+                    throw new IllegalArgumentException("couldn't select option with text or value: $valueString, available values: $availableValues")
                 }
             }
         }

--- a/module/geb-core/src/test/groovy/geb/navigator/SelectControlSpec.groovy
+++ b/module/geb-core/src/test/groovy/geb/navigator/SelectControlSpec.groovy
@@ -44,7 +44,8 @@ class SelectControlSpec extends GebSpecWithCallbackServer {
         $().s1 = "o3"
 
         then:
-        thrown(IllegalArgumentException)
+        IllegalArgumentException e = thrown()
+        e.message.contains 'available values: [o1, o2]'
 
         when:
         $().s1 = "o2"


### PR DESCRIPTION
Currently, if an option cannot be selected from a `select` element, you get a trace like
```
java.lang.IllegalArgumentException: couldn't select option with text or value: foo
	at geb.navigator.NonEmptyNavigator.setSelectValue(NonEmptyNavigator.groovy:738)
	at geb.navigator.NonEmptyNavigator.setInputValue(NonEmptyNavigator.groovy:690)
	at geb.navigator.NonEmptyNavigator.setInputValues_closure42(NonEmptyNavigator.groovy:684)
	at groovy.lang.Closure.call(Closure.java:423)
	at groovy.lang.Closure.call(Closure.java:439)
	at geb.navigator.NonEmptyNavigator.setInputValues(NonEmptyNavigator.groovy:683)
	at geb.navigator.NonEmptyNavigator.value(NonEmptyNavigator.groovy:441)
	at geb.content.TemplateDerivedPageContent.value(TemplateDerivedPageContent.groovy:27)
```
It would help if the select's available option values were included in the error message.