### PR TITLE
support forcelocal same as application

### DIFF
--- a/integration/geb-gradle/src/main/groovy/geb/gradle/browserstack/BrowserStackExtension.groovy
+++ b/integration/geb-gradle/src/main/groovy/geb/gradle/browserstack/BrowserStackExtension.groovy
@@ -23,6 +23,7 @@ class BrowserStackExtension {
     Project project
     BrowserStackAccount account
     List<URL> applicationUrls = []
+    boolean forcelocal = false
 
     BrowserStackExtension(Project project) {
         this.project = project
@@ -31,7 +32,7 @@ class BrowserStackExtension {
     void addExtensions() {
         extensions.browsers = project.container(BrowserSpec) { new BrowserSpec("browserstack", it) }
         account = new BrowserStackAccount()
-        extensions.create('tunnel', BrowserStackTunnel, project, project.logger, account, applicationUrls)
+        extensions.create('tunnel', BrowserStackTunnel, project, project.logger, account, applicationUrls, forcelocal)
     }
 
     void task(Closure configuration) {
@@ -53,5 +54,9 @@ class BrowserStackExtension {
 
     void application(URL... urls) {
         applicationUrls.addAll(urls)
+    }
+
+    void forcelocal(boolean forcelocal) {
+        this.forcelocal = forcelocal
     }
 }

--- a/integration/geb-gradle/src/main/groovy/geb/gradle/browserstack/BrowserStackTunnel.groovy
+++ b/integration/geb-gradle/src/main/groovy/geb/gradle/browserstack/BrowserStackTunnel.groovy
@@ -25,14 +25,16 @@ class BrowserStackTunnel extends ExternalTunnel {
 
     final protected BrowserStackAccount account
     final protected List<URL> applicationUrls
+    final protected boolean forcelocal
 
     final String outputPrefix = 'browserstack-tunnel'
     final String tunnelReadyMessage = 'You can now access your local server(s) in our remote browser.'
 
-    BrowserStackTunnel(Project project, Logger logger, BrowserStackAccount account, List<URL> applicationUrls) {
+    BrowserStackTunnel(Project project, Logger logger, BrowserStackAccount account, List<URL> applicationUrls, boolean forcelocal) {
         super(project, logger)
         this.account = account
         this.applicationUrls = applicationUrls
+        this.forcelocal = forcelocal
     }
 
     @Override
@@ -52,6 +54,9 @@ class BrowserStackTunnel extends ExternalTunnel {
         }
         if (applicationUrls) {
             commandLine << "-only" << assembleAppSpecifier(applicationUrls)
+        }
+        if (forcelocal) {
+            commandLine << "-forcelocal"
         }
         commandLine
     }


### PR DESCRIPTION
opening tunnel with browser stack requires sometimes to use the local network.
adding the ability to set the flag -forcelocal to the tunnel executable.

in browserstack task just need to use:
forcelocal true