### PR TITLE
add a Factory that restarts the browser with every usage

### DIFF
--- a/module/geb-core/src/main/groovy/geb/Configuration.groovy
+++ b/module/geb-core/src/main/groovy/geb/Configuration.groovy
@@ -197,6 +197,18 @@ class Configuration {
     }
 
     /**
+     * The driver is to be cached, this setting controls whether or not the driver is cached per thread but reseting the browser
+     * (quiting and opening a new instance),
+     * or per
+     * <p>
+     * The value is the config entry {@code cacheDriverPerThread}, which defaults to {@code true}.
+     */
+    boolean isCacheDriverPerThreadWithReset() {
+        readValue('cacheDriverPerThreadWithReset', false)
+    }
+
+
+    /**
      * The driver is to be cached, this setting controls whether or not the driver is cached per thread,
      * or per
      * <p>
@@ -461,7 +473,16 @@ class Configuration {
 
     protected DriverFactory wrapDriverFactoryInCachingIfNeeded(DriverFactory factory) {
         if (isCacheDriver()) {
-            isCacheDriverPerThread() ? CachingDriverFactory.perThread(factory, isQuitCachedDriverOnShutdown()) : CachingDriverFactory.global(factory, isQuitCachedDriverOnShutdown())
+
+            if(isCacheDriverPerThread()){
+                return CachingDriverFactory.perThread(factory, isQuitCachedDriverOnShutdown())
+            }
+
+            if(isCacheDriverPerThreadWithReset()){
+                return CachingDriverFactory.perThreadWithReset(factory, isQuitCachedDriverOnShutdown())
+            }
+
+            return CachingDriverFactory.global(factory, isQuitCachedDriverOnShutdown())
         } else {
             factory
         }

--- a/module/geb-core/src/main/groovy/geb/Configuration.groovy
+++ b/module/geb-core/src/main/groovy/geb/Configuration.groovy
@@ -207,7 +207,6 @@ class Configuration {
         readValue('cacheDriverPerThreadWithReset', false)
     }
 
-
     /**
      * The driver is to be cached, this setting controls whether or not the driver is cached per thread,
      * or per

--- a/module/geb-core/src/main/groovy/geb/driver/CachingDriverFactory.groovy
+++ b/module/geb-core/src/main/groovy/geb/driver/CachingDriverFactory.groovy
@@ -50,7 +50,6 @@ class CachingDriverFactory implements DriverFactory {
             if (cached != null) {
                 try{
                     cached.quit()
-                
                 }catch(Throwable e){
                 }
                 cached = null

--- a/module/geb-core/src/main/groovy/geb/driver/CachingDriverFactory.groovy
+++ b/module/geb-core/src/main/groovy/geb/driver/CachingDriverFactory.groovy
@@ -41,6 +41,29 @@ class CachingDriverFactory implements DriverFactory {
         }
     }
 
+    static private class ThreadLocalCacheWithReset<T> implements Cache<T> {
+        private ThreadLocal<T> threadLocal = new ThreadLocal()
+
+        synchronized T get(Closure<? extends T> factory) {
+            def cached = threadLocal.get()
+
+            if (cached != null) {
+                try{ cached.quit() }catch(Exception e){}
+                cached = null
+            }
+
+            cached = factory()
+            threadLocal.set(cached)
+            cached
+        }
+
+        synchronized T clear() {
+            def prev = threadLocal.get()
+            threadLocal.set(null)
+            prev
+        }
+    }
+
     static private class ThreadLocalCache<T> implements Cache<T> {
         private ThreadLocal<T> threadLocal = new ThreadLocal()
 
@@ -74,6 +97,10 @@ class CachingDriverFactory implements DriverFactory {
 
     static CachingDriverFactory global(DriverFactory innerFactory, boolean quitOnShutdown) {
         new CachingDriverFactory(CACHE.get { new SimpleCache<WebDriver>() }, innerFactory, quitOnShutdown)
+    }
+
+    static CachingDriverFactory perThreadWithReset(DriverFactory innerFactory, boolean quitOnShutdown) {
+        new CachingDriverFactory(CACHE.get { new ThreadLocalCacheWithReset<WebDriver>() }, innerFactory, quitOnShutdown)
     }
 
     static CachingDriverFactory perThread(DriverFactory innerFactory, boolean quitOnShutdown) {


### PR DESCRIPTION
I have a test batery that runs in parallel several browsers, and sometimes to clear the cookies is not enough. I need to quit that instance of the browser and to create a new one.

With this PR you can configurate this with the variable cacheDriverPerThreadWithReset