### PR TITLE
Adding optional cause message to Wait time-out exceptions

### DIFF
--- a/module/geb-core/src/main/groovy/geb/Configuration.groovy
+++ b/module/geb-core/src/main/groovy/geb/Configuration.groovy
@@ -94,7 +94,7 @@ class Configuration {
         } else if (waitingParam instanceof Number && waitingParam > 0) {
             getWait(waitingParam.doubleValue())
         } else if (waitingParam instanceof Collection) {
-            if (waitingParam.size() == 2 || waitingParam.size() == 3) {
+            if (waitingParam.size() > 1 && waitingParam.size() < 4) {
                 def timeout = waitingParam[0]
                 def retryInterval = waitingParam[1]
                 def printCause = getDefaultWaitPrintCause()

--- a/module/geb-core/src/test/groovy/geb/waiting/WaitingContentSpec.groovy
+++ b/module/geb-core/src/test/groovy/geb/waiting/WaitingContentSpec.groovy
@@ -74,6 +74,14 @@ class WaitingContentSpec extends WaitingSpec {
         content
     }
 
+    def "custom retry and printCause"() {
+        when:
+        params = [wait: [5, 1, true]]
+
+        then:
+        content
+    }
+
     def "wait preset"() {
         when:
         params = [wait: "somepreset"]
@@ -94,7 +102,7 @@ class WaitingContentSpec extends WaitingSpec {
         thrown IllegalArgumentException
 
         where:
-        value << [[], [1], [1, 2, 3], ["asds", "asdas"]]
+        value << [[], [1], [1, 2, true, 4], [1, 2, 3], ["asds", 1], [1, "asdas"]]
     }
 
     def "waiting for non content - fail"() {

--- a/module/geb-waiting/src/main/groovy/geb/waiting/Wait.groovy
+++ b/module/geb-waiting/src/main/groovy/geb/waiting/Wait.groovy
@@ -32,6 +32,8 @@ class Wait {
      */
     static public final Double DEFAULT_RETRY_INTERVAL = 0.1
 
+    static public final boolean DEFAULT_PRINT_CAUSE = false
+
     private static final int HASHCODE_MULTIPLIER = 31
 
     /**
@@ -44,11 +46,17 @@ class Wait {
      */
     final Double retryInterval
 
+    /**
+     * Whether we should append cause strings to the returned exception message or not
+     */
+    final boolean printCause
+
     String customMessage
 
-    Wait(Double timeout = DEFAULT_TIMEOUT, Double retryInterval = DEFAULT_RETRY_INTERVAL) {
+    Wait(Double timeout = DEFAULT_TIMEOUT, Double retryInterval = DEFAULT_RETRY_INTERVAL, boolean printCause = DEFAULT_PRINT_CAUSE) {
         this.timeout = timeout
         this.retryInterval = [timeout, retryInterval].min()
+        this.printCause = printCause
     }
 
     String toString() {

--- a/module/geb-waiting/src/main/groovy/geb/waiting/WaitTimeoutException.java
+++ b/module/geb-waiting/src/main/groovy/geb/waiting/WaitTimeoutException.java
@@ -52,7 +52,7 @@ public class WaitTimeoutException extends GebException {
             message.append(String.format("(%s)", wait.getCustomMessage()));
         }
         if (cause != null) {
-            message.append(" (failed with exception)");
+            message.append("Failed with exception:" + cause);
         }
         return message.toString();
     }

--- a/module/geb-waiting/src/main/groovy/geb/waiting/WaitTimeoutException.java
+++ b/module/geb-waiting/src/main/groovy/geb/waiting/WaitTimeoutException.java
@@ -52,7 +52,11 @@ public class WaitTimeoutException extends GebException {
             message.append(String.format("(%s)", wait.getCustomMessage()));
         }
         if (cause != null) {
-            message.append("Failed with exception:" + cause);
+            if (wait.getPrintCause()) {
+                message.append(" Failed with exception: " + cause);
+            } else {
+                message.append(" (failed with exception)");
+            }
         }
         return message.toString();
     }

--- a/module/geb-waiting/src/test/groovy/geb/waiting/WaitSpec.groovy
+++ b/module/geb-waiting/src/test/groovy/geb/waiting/WaitSpec.groovy
@@ -49,4 +49,16 @@ class WaitSpec extends Specification {
         exception.cause.message.contains("'not empty'.empty")
     }
 
+    def "waitFor block exception message contains cause"() {
+        given:
+        def wait = new Wait(0.5)
+
+        when:
+        wait.waitFor { 'not empty'.empty }
+
+        then:
+        WaitTimeoutException exception = thrown()
+        exception.message.contains("'not empty'.empty")
+    }
+
 }

--- a/module/geb-waiting/src/test/groovy/geb/waiting/WaitSpec.groovy
+++ b/module/geb-waiting/src/test/groovy/geb/waiting/WaitSpec.groovy
@@ -49,7 +49,7 @@ class WaitSpec extends Specification {
         exception.cause.message.contains("'not empty'.empty")
     }
 
-    def "waitFor block exception message contains cause"() {
+    def "waitFor block default exception message does not contain cause"() {
         given:
         def wait = new Wait(0.5)
 
@@ -58,7 +58,18 @@ class WaitSpec extends Specification {
 
         then:
         WaitTimeoutException exception = thrown()
-        exception.message.contains("'not empty'.empty")
+        !exception.message.contains("'not empty'.empty")
     }
 
+    def "waitFor block exception message contains cause when enabled"() {
+        given:
+        def wait = new Wait(0.5, Wait.DEFAULT_RETRY_INTERVAL, true)
+
+        when:
+        wait.waitFor { 'not empty'.empty }
+
+        then:
+        WaitTimeoutException exception = thrown()
+        exception.message.contains("'not empty'.empty")
+    }
 }


### PR DESCRIPTION
Users would like to see more information when a Wait time-out exception occurs and providing the cause of the exception improves productivity.

The output of Maven/Gradle error reporting tool is especially improved.