### PR TITLE
[fix] delegate to the correct waitFor

### DIFF
--- a/module/geb-core/src/main/groovy/geb/Page.groovy
+++ b/module/geb-core/src/main/groovy/geb/Page.groovy
@@ -513,7 +513,7 @@ class Page implements Navigable, PageContentContainer, Initializable, WaitingSup
 
     @Override
     def <T> T waitFor(Map params = [:], Double timeout, Double interval, Closure<T> block) {
-        waitingSupport.waitFor(params, interval, block)
+        waitingSupport.waitFor(params, timeout, interval, block)
     }
 
     GebException uninitializedException() {


### PR DESCRIPTION
While upgrading to the latest geb version I found
that a lot of tests were failing. I then noticed that
the applied timeout was actually the interval.

