### PR TITLE
Add support for non-ASCII letters in test names

### DIFF
--- a/module/geb-core/src/main/groovy/geb/report/ReporterSupport.groovy
+++ b/module/geb-core/src/main/groovy/geb/report/ReporterSupport.groovy
@@ -32,7 +32,7 @@ abstract class ReporterSupport implements Reporter {
      * Replaces all non word chars with underscores to avoid using reserved characters in file paths
      */
     protected escapeFileName(String name) {
-        name.replaceAll("[^\\w\\s-]", "_")
+        name.replaceAll("(?U)[^\\w\\s-]", "_")
     }
 
     void addListener(ReportingListener listener) {

--- a/module/geb-core/src/test/groovy/geb/report/ReporterSupportSpec.groovy
+++ b/module/geb-core/src/test/groovy/geb/report/ReporterSupportSpec.groovy
@@ -29,15 +29,15 @@ class ReporterSupportSpec extends Specification {
         given:
         def reporter = new ReporterSupport() {
             void writeReport(ReportState reportState) {
-                getFile(reportState.outputDir, reportState.label, "12 | 34") << "content"
+                getFile(reportState.outputDir, reportState.label, "12 | 34 | zф") << "content"
             }
         }
 
         when:
-        reporter.writeReport(new ReportState(null, "12 | 34", reportDir))
+        reporter.writeReport(new ReportState(null, "12 | 34 | zф", reportDir))
 
         then:
-        new File(reportDir, "12 _ 34.12 _ 34").exists()
+        new File(reportDir, "12 _ 34 _ zф.12 _ 34 _ zф").exists()
     }
 
     def "listener added more than once is not called twice"() {


### PR DESCRIPTION
Hi!

It would be very useful to have readable test names for non-English speakers. But, currently, these names are mutated into the pile of underscore symbols in reports. Following simple change in escaping regexp should help.