### PR TITLE
fix issue #407

### DIFF
--- a/module/geb-testng/src/main/groovy/geb/testng/GebReportingTest.groovy
+++ b/module/geb-testng/src/main/groovy/geb/testng/GebReportingTest.groovy
@@ -20,6 +20,7 @@ import org.testng.ITestResult
 import org.testng.annotations.AfterMethod
 import org.testng.annotations.BeforeClass
 import org.testng.annotations.BeforeMethod
+import org.testng.annotations.BeforeSuite
 
 import java.lang.reflect.Method
 
@@ -35,7 +36,7 @@ class GebReportingTest extends GebTest {
     }
 
     @SuppressWarnings("GroovyUnusedDeclaration")
-    @BeforeClass
+    @BeforeSuite
     void initReportGroupDir() {
         browser.cleanReportGroupDir()
     }


### PR DESCRIPTION
Only the last class in a test suite would leave reports because they were being cleaned before each test class.