### PR TITLE
open up property to be able to access it within specs.

### DIFF
--- a/module/geb-spock/src/main/groovy/geb/spock/GebReportingSpec.groovy
+++ b/module/geb-spock/src/main/groovy/geb/spock/GebReportingSpec.groovy
@@ -24,9 +24,9 @@ class GebReportingSpec extends GebSpec {
     // Ridiculous name to avoid name clashes
     @Rule
     TestName gebReportingSpecTestName
-    private int gebReportingPerTestCounter = 1
+    protected int gebReportingPerTestCounter = 1
     @Shared
-    private int gebReportingSpecTestCounter = 1
+    protected int gebReportingSpecTestCounter = 1
 
     def setupSpec() {
         reportGroup getClass()


### PR DESCRIPTION
In order to be able to save files within a Specification it is necessary to open up these properties to subclasses.

Usecase:
- my Specification class has got a method named 'my test method'
if I do report() a file is written with 001-001<some name>

In order to save a file within my test method it would be helpful to save it with the same prefix that the files from report() calls.
