### PR TITLE
reportOnTestFailureOnly implementation for Spock (issue #92)

### DIFF
--- a/doc/manual-snippets/src/test/groovy/reporting/ReportingSpec.groovy
+++ b/doc/manual-snippets/src/test/groovy/reporting/ReportingSpec.groovy
@@ -45,11 +45,11 @@ class ReportingSpec extends DriveMethodSupportingSpecWithServer {
             assert new File(config.reportsDir, "google/home page.html").exists()
 
             // tag::reporting_groups[]
-            reportGroup "wikipedia"
-            go "http://wikipedia.org"
+            reportGroup "github"
+            go "http://github.com"
             report "home page"
             // end::reporting_groups[]
-            assert new File(config.reportsDir, "wikipedia/home page.html").exists()
+            assert new File(config.reportsDir, "github/home page.html").exists()
             // tag::reporting_groups[]
         }
         // end::reporting_groups[]

--- a/module/geb-spock/src/main/groovy/geb/spock/FailTrackerRule.groovy
+++ b/module/geb-spock/src/main/groovy/geb/spock/FailTrackerRule.groovy
@@ -27,6 +27,7 @@ class FailTrackerRule implements MethodRule {
 
     Statement apply(Statement statement, FrameworkMethod frameworkMethod, Object o) {
         o.toString() // added to avoid codeNarc errors
+        frameworkMethod.toString() // added to avoid codeNarc errors
         new Statement() {
             @Override
             void evaluate() throws Throwable {

--- a/module/geb-spock/src/main/groovy/geb/spock/FailTrackerRule.groovy
+++ b/module/geb-spock/src/main/groovy/geb/spock/FailTrackerRule.groovy
@@ -23,7 +23,7 @@ import org.junit.runners.model.Statement
  */
 class FailTrackerRule implements MethodRule {
 
-    static failedTests = []
+    boolean failed = false
 
     Statement apply(Statement statement, FrameworkMethod frameworkMethod, Object o) {
         o.toString() // added to avoid codeNarc errors
@@ -33,7 +33,7 @@ class FailTrackerRule implements MethodRule {
                 try {
                     statement.evaluate()
                 } catch (Throwable t) {
-                    failedTests.add(frameworkMethod.getName())
+                    failed = true
                     throw t
                 }
             }

--- a/module/geb-spock/src/main/groovy/geb/spock/FailTrackerRule.groovy
+++ b/module/geb-spock/src/main/groovy/geb/spock/FailTrackerRule.groovy
@@ -21,7 +21,7 @@ import org.junit.runners.model.Statement
 /**
  * Created by leo-13 on 11/11/2015.
  */
-class MethodExecutionRule implements MethodRule {
+class FailTrackerRule implements MethodRule {
 
     static failedTests = []
 

--- a/module/geb-spock/src/main/groovy/geb/spock/GebReportingSpec.groovy
+++ b/module/geb-spock/src/main/groovy/geb/spock/GebReportingSpec.groovy
@@ -40,7 +40,7 @@ class GebReportingSpec extends GebSpec {
     }
 
     def cleanup() {
-        if (failTracker.failedTests.contains(gebReportingSpecTestName.methodName)) {
+        if (failTracker.failed) {
             report "failure"
         } else if (!browser.config.reportOnTestFailureOnly) {
             report "end"

--- a/module/geb-spock/src/main/groovy/geb/spock/GebReportingSpec.groovy
+++ b/module/geb-spock/src/main/groovy/geb/spock/GebReportingSpec.groovy
@@ -11,14 +11,13 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package geb.spock
 
 import geb.report.ReporterSupport
-import spock.lang.*
 import org.junit.Rule
 import org.junit.rules.TestName
+import spock.lang.Shared
 
 class GebReportingSpec extends GebSpec {
 

--- a/module/geb-spock/src/main/groovy/geb/spock/GebReportingSpec.groovy
+++ b/module/geb-spock/src/main/groovy/geb/spock/GebReportingSpec.groovy
@@ -15,9 +15,9 @@
 package geb.spock
 
 import geb.report.ReporterSupport
+import spock.lang.*
 import org.junit.Rule
 import org.junit.rules.TestName
-import spock.lang.Shared
 
 class GebReportingSpec extends GebSpec {
 

--- a/module/geb-spock/src/main/groovy/geb/spock/GebReportingSpec.groovy
+++ b/module/geb-spock/src/main/groovy/geb/spock/GebReportingSpec.groovy
@@ -40,14 +40,16 @@ class GebReportingSpec extends GebSpec {
     }
 
     def cleanup() {
-        report "end"
+        if (failTracker.failedTests.contains(gebReportingSpecTestName.methodName)) {
+            report "failure"
+        } else if (!browser.config.reportOnTestFailureOnly) {
+            report "end"
+        }
         ++gebReportingSpecTestCounter
     }
 
     void report(String label = "") {
-        if (!browser.config.reportOnTestFailureOnly || failTracker.failedTests.contains(gebReportingSpecTestName.methodName)) {
-            browser.report(ReporterSupport.toTestReportLabel(gebReportingSpecTestCounter, gebReportingPerTestCounter++, gebReportingSpecTestName.methodName, label))
-        }
+        browser.report(ReporterSupport.toTestReportLabel(gebReportingSpecTestCounter, gebReportingPerTestCounter++, gebReportingSpecTestName.methodName, label))
     }
 
 }

--- a/module/geb-spock/src/main/groovy/geb/spock/GebReportingSpec.groovy
+++ b/module/geb-spock/src/main/groovy/geb/spock/GebReportingSpec.groovy
@@ -22,7 +22,7 @@ import org.junit.rules.TestName
 class GebReportingSpec extends GebSpec {
 
     @Rule
-    MethodExecutionRule failTracker = new MethodExecutionRule()
+    FailTrackerRule failTracker = new FailTrackerRule()
     // Ridiculous name to avoid name clashes
     @Rule
     TestName gebReportingSpecTestName

--- a/module/geb-spock/src/main/groovy/geb/spock/MethodExecutionRule.groovy
+++ b/module/geb-spock/src/main/groovy/geb/spock/MethodExecutionRule.groovy
@@ -1,3 +1,17 @@
+/* Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package geb.spock
 
 import org.junit.rules.MethodRule
@@ -7,18 +21,19 @@ import org.junit.runners.model.Statement
 /**
  * Created by leo-13 on 11/11/2015.
  */
-public class MethodExecutionRule implements MethodRule {
+class MethodExecutionRule implements MethodRule {
 
-    public static failedTests = [] //list of failed tests
+    static failedTests = []
 
-    public Statement apply(final Statement statement, final FrameworkMethod frameworkMethod, final Object o) {
-        return new Statement() {
+    Statement apply(Statement statement, FrameworkMethod frameworkMethod, Object o) {
+        o.toString() // added to avoid codeNarc errors
+        new Statement() {
             @Override
-            public void evaluate() throws Throwable {
+            void evaluate() throws Throwable {
                 try {
                     statement.evaluate()
                 } catch (Throwable t) {
-                    failedTests.add(frameworkMethod.getName()) //only adds failed tests
+                    failedTests.add(frameworkMethod.getName())
                     throw t
                 }
             }

--- a/module/geb-spock/src/main/groovy/geb/spock/MethodExecutionRule.groovy
+++ b/module/geb-spock/src/main/groovy/geb/spock/MethodExecutionRule.groovy
@@ -9,7 +9,7 @@ import org.junit.runners.model.Statement
  */
 public class MethodExecutionRule implements MethodRule {
 
-    public static def failedTests = [] //list of failed tests
+    public static failedTests = [] //list of failed tests
 
     public Statement apply(final Statement statement, final FrameworkMethod frameworkMethod, final Object o) {
         return new Statement() {

--- a/module/geb-spock/src/test/groovy/geb/spock/GebReportingSpecSpec.groovy
+++ b/module/geb-spock/src/test/groovy/geb/spock/GebReportingSpecSpec.groovy
@@ -68,7 +68,7 @@ class GebReportingSpecSpec extends GebReportingSpec {
 
     def "there are no failed tests"() {
         expect:
-        failTracker.failedTests.isEmpty()
+        !failTracker.failed
     }
 
     def "reportOnTestFailureOnly is enabled - passing test"() {
@@ -79,13 +79,13 @@ class GebReportingSpecSpec extends GebReportingSpec {
     def "reportOnTestFailureOnly is enabled - failing test"() {
         given:
         config.reportOnTestFailureOnly = true
-        failTracker.failedTests.add(specificationContext.currentIteration.name)
+        failTracker.failed = true
     }
 
     def "reportOnTestFailureOnly is disabled - failing test"() {
         given:
         config.reportOnTestFailureOnly = false
-        failTracker.failedTests.add(specificationContext.currentIteration.name)
+        failTracker.failed = true
     }
 
     def "there should be no report for the passing test when reportOnTestFailureOnly is enabled"() {
@@ -93,7 +93,7 @@ class GebReportingSpecSpec extends GebReportingSpec {
         !reportGroupDir.listFiles().any { it.name.contains("reportOnTestFailureOnly is enabled - passing test-end") }
     }
 
-    def "there should be a report for the failing test when reportOnTestFailureOnly is enabled"() {
+    def "there should be reports for the failing tests with label 'failure'"() {
         expect:
         reportGroupDir.listFiles().any { it.name.contains("reportOnTestFailureOnly is enabled - failing test-failure") }
         reportGroupDir.listFiles().any { it.name.contains("reportOnTestFailureOnly is disabled - failing test-failure") }

--- a/module/geb-spock/src/test/groovy/geb/spock/GebReportingSpecSpec.groovy
+++ b/module/geb-spock/src/test/groovy/geb/spock/GebReportingSpecSpec.groovy
@@ -96,9 +96,7 @@ class GebReportingSpecSpec extends GebReportingSpec {
     def "there should be a report for the failing test when reportOnTestFailureOnly is enabled"() {
         expect:
         reportGroupDir.listFiles().any { it.name.contains("reportOnTestFailureOnly is enabled - failing test-failure") }
-        reportGroupDir.listFiles().any {
-            it.name.contains("reportOnTestFailureOnly is disabled - failing test-failure")
-        }
+        reportGroupDir.listFiles().any { it.name.contains("reportOnTestFailureOnly is disabled - failing test-failure") }
     }
 
     def cleanupSpec() {

--- a/module/geb-spock/src/test/groovy/geb/spock/GebReportingSpecSpec.groovy
+++ b/module/geb-spock/src/test/groovy/geb/spock/GebReportingSpecSpec.groovy
@@ -82,14 +82,23 @@ class GebReportingSpecSpec extends GebReportingSpec {
         failTracker.failedTests.add(specificationContext.currentIteration.name)
     }
 
+    def "reportOnTestFailureOnly is disabled - failing test"() {
+        given:
+        config.reportOnTestFailureOnly = false
+        failTracker.failedTests.add(specificationContext.currentIteration.name)
+    }
+
     def "there should be no report for the passing test when reportOnTestFailureOnly is enabled"() {
         expect:
-        !reportGroupDir.listFiles().any { it.name.contains("passing test") }
+        !reportGroupDir.listFiles().any { it.name.contains("reportOnTestFailureOnly is enabled - passing test-end") }
     }
 
     def "there should be a report for the failing test when reportOnTestFailureOnly is enabled"() {
         expect:
-        reportGroupDir.listFiles().any { it.name.contains("failing test") }
+        reportGroupDir.listFiles().any { it.name.contains("reportOnTestFailureOnly is enabled - failing test-failure") }
+        reportGroupDir.listFiles().any {
+            it.name.contains("reportOnTestFailureOnly is disabled - failing test-failure")
+        }
     }
 
     def cleanupSpec() {


### PR DESCRIPTION
reportOnTestFailureOnly option is now working for Spock integration, without changing the Spock code. Implemented via JUnit MethodRule interface. If approved can be later used for Geb-JUnit integration as well.