### PR TITLE
Allow proxy server parameters to be specified in account details

### DIFF
--- a/integration/geb-gradle/src/main/groovy/geb/gradle/browserstack/BrowserStackAccount.groovy
+++ b/integration/geb-gradle/src/main/groovy/geb/gradle/browserstack/BrowserStackAccount.groovy
@@ -21,10 +21,18 @@ class BrowserStackAccount {
     public static final String USER_ENV_VAR = "GEB_BROWSERSTACK_USERNAME"
     public static final String ACCESS_KEY_ENV_VAR = "GEB_BROWSERSTACK_AUTHKEY"
     public static final String LOCAL_ID_ENV_VAR = "GEB_BROWSERSTACK_LOCALID"
+    public static final String PROXY_HOST_ENV_VAR = "GEB_BROWSERSTACK_PROXY_HOST"
+    public static final String PROXY_PORT_ENV_VAR = "GEB_BROWSERSTACK_PROXY_PORT"
+    public static final String PROXY_USER_ENV_VAR = "GEB_BROWSERSTACK_PROXY_USER"
+    public static final String PROXY_PASS_ENV_VAR = "GEB_BROWSERSTACK_PROXY_PASS"
 
     String username
     String accessKey
     String localId
+    String proxyHost
+    String proxyPort
+    String proxyUser
+    String proxyPass
 
     void configure(Test test) {
         if (username) {
@@ -35,6 +43,18 @@ class BrowserStackAccount {
         }
         if (localId) {
             test.environment(LOCAL_ID_ENV_VAR, localId)
+        }
+        if (proxyHost) {
+            test.environment(PROXY_HOST_ENV_VAR, proxyHost)
+        }
+        if (proxyPort) {
+            test.environment(PROXY_PORT_ENV_VAR, proxyPort)
+        }
+        if (proxyUser) {
+            test.environment(PROXY_USER_ENV_VAR, proxyUser)
+        }
+        if (proxyPass) {
+            test.environment(PROXY_PASS_ENV_VAR, proxyPass)
         }
     }
 }

--- a/integration/geb-gradle/src/main/groovy/geb/gradle/browserstack/BrowserStackTunnel.groovy
+++ b/integration/geb-gradle/src/main/groovy/geb/gradle/browserstack/BrowserStackTunnel.groovy
@@ -51,6 +51,19 @@ class BrowserStackTunnel extends ExternalTunnel {
         if (extension.applicationUrls) {
             commandLine << "-only" << assembleAppSpecifier(extension.applicationUrls)
         }
+        if( extension.account.proxyHost){
+            commandLine << "-proxyHost" << extension.account.proxyHost
+        }
+        if( extension.account.proxyPort){
+            commandLine << "-proxyPort" << extension.account.proxyPort
+        }
+
+        if( extension.account.proxyUser){
+            commandLine << "-proxyUser" << extension.account.proxyUser
+        }
+        if( extension.account.proxyPass){
+            commandLine << "-proxyPass" << extension.account.proxyPass
+        }
         if (extension.forceLocal) {
             commandLine << "-forcelocal"
         }


### PR DESCRIPTION
Made changes to 
\integration\geb-gradle\src\main\groovy\geb\gradle\browserstack\BrowserStackAccount.groovy
\integration\geb-gradle\src\main\groovy\geb\gradle\browserstack\BrowserStackTunnel.groovy
to allow proxy server parameters to be specified in account details so tunnel can connect e.g. in corporate environments

       browserStack {
       ...
       account{
       ...
       	       username = 'fred' // System.getenv(BrowserStackAccount.USER_ENV_VAR)
               accessKey = 'SomeAccessKey' // System.getenv(BrowserStackAccount.ACCESS_KEY_ENV_VAR)
               proxyHost = '10.1.100.154'
               proxyPort = '8080'
               proxyUser = 'chrisby'
               proxyPass = 'chrisbypass'