### PR TITLE
GEB-422: HashMap.Values class in Groovy versions before 2.4.0 doesn't have a 'minus' method - converting it to a List to work with Groovy versions before 2.4.0

### DIFF
--- a/compatibility/groovy-2-3-7/groovy-2-3-7.gradle
+++ b/compatibility/groovy-2-3-7/groovy-2-3-7.gradle
@@ -1,0 +1,18 @@
+apply plugin: "groovy"
+apply plugin: "idea"
+
+dependencies {
+    compile project(':module:geb-core'), {
+        exclude module: "groovy-all"
+        exclude module: "spock-core"
+    }
+
+    compile "org.codehaus.groovy:groovy-all:2.3.7"
+
+    testCompile "org.spockframework:spock-core:1.0-groovy-2.3"
+
+    testCompile project(':internal:test-support'), {
+        exclude module: "groovy-all"
+        exclude module: "spock-core"
+    }
+}

--- a/compatibility/groovy-2-3-7/src/test/groovy/geb/NavigatorCompatibilitySpec.groovy
+++ b/compatibility/groovy-2-3-7/src/test/groovy/geb/NavigatorCompatibilitySpec.groovy
@@ -1,0 +1,27 @@
+package geb
+
+import geb.test.GebSpecWithCallbackServer
+import spock.lang.Issue
+
+class NavigatorCompatibilitySpec extends GebSpecWithCallbackServer {
+    def setupSpec() {
+        responseHtml {
+            body {
+                input(type: "text", id: "my-input", value: "val")
+            }
+        }
+    }
+
+    def setup() {
+        go()
+    }
+
+    @Issue("https://github.com/geb/issues/issues/422")
+    def 'can set form input field value with Groovy 2.3.7'() {
+        when:
+        $('#my-input').value('newValue')
+
+        then:
+        $('#my-input').value() == 'newValue'
+    }
+}

--- a/geb.gradle
+++ b/geb.gradle
@@ -101,17 +101,6 @@ subprojects {
 
         sourceCompatibility = 1.7
 
-        tasks.withType(Test) {
-            reports.junitXml.destination = reporting.file("test-results/$name")
-            reports.html.destination = reporting.file("test-reports/$name")
-            binResultsDir = file("$buildDir/test-results-bin/$name")
-
-            ext.driver = project.properties["driver"] ?: "htmlunit"
-            systemProperty 'geb.dev.driver', driver
-
-            systemProperty 'geb.build.reportsDir', reporting.file("geb-reports/$name")
-        }
-
         codenarc.configFile = rootProject.file('gradle/codenarc/rulesets.groovy')
 
         project.tasks.withType(CodeNarc) { codenarcSourceSetTask ->
@@ -151,6 +140,17 @@ subprojects {
                 }
             }
         }
+    }
+
+    tasks.withType(Test) {
+        reports.junitXml.destination = reporting.file("test-results/$name")
+        reports.html.destination = reporting.file("test-reports/$name")
+        binResultsDir = file("$buildDir/test-results-bin/$name")
+
+        ext.driver = project.properties["driver"] ?: "htmlunit"
+        systemProperty 'geb.dev.driver', driver
+
+        systemProperty 'geb.build.reportsDir', reporting.file("geb-reports/$name")
     }
 
     tasks.withType(Groovydoc) {

--- a/module/geb-core/src/main/groovy/geb/navigator/NonEmptyNavigator.groovy
+++ b/module/geb-core/src/main/groovy/geb/navigator/NonEmptyNavigator.groovy
@@ -701,7 +701,7 @@ class NonEmptyNavigator extends AbstractNavigator {
 
     protected void setInputValues(Collection<WebElement> inputs, value) {
         def inputsToTagNames = inputs.collectEntries { [it, it.tagName.toLowerCase()] }
-        def unsupportedElements = inputsToTagNames.values() - ELEMENTS_WITH_MUTABLE_VALUE
+        def unsupportedElements = inputsToTagNames.values().toList() - ELEMENTS_WITH_MUTABLE_VALUE
 
         if (unsupportedElements) {
             throw new UnableToSetElementException(*unsupportedElements)

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,7 +13,8 @@ include "module:geb-core",
     "integration:geb-gradle",
     "doc:manual",
     "doc:manual-snippets",
-    "doc:site"
+    "doc:site",
+    "compatibility:groovy-2-3-7"
 
 rootProject.name = 'geb'
 


### PR DESCRIPTION
Background info in https://github.com/geb/issues/issues/422

To fully test that this fix works with Groovy versions < 2.4.0 I had to change the Groovy version in geb-grails.gradle from "project.groovyVersion" (2.4.5) to "2.3.7" (2.3.7 is the Groovy version that ships with Grails 2.4.2 which is Grails version used in geb-grails.gradle). I thought about committing that change but I didn't know if it would affect building/publishing the Grails plugin so I left it out. If you'd prefer that I commit that change just let me know and I'll include it. Or if you know of a way to set the Groovy version for the tests only that might work as well.