### PR TITLE
Content wrapper can be casted to a wrapped type

### DIFF
--- a/module/geb-core/src/main/groovy/geb/content/TemplateDerivedPageContent.groovy
+++ b/module/geb-core/src/main/groovy/geb/content/TemplateDerivedPageContent.groovy
@@ -17,6 +17,7 @@ package geb.content
 import geb.Browser
 import geb.error.RequiredPageContentNotPresent
 import geb.navigator.Navigator
+import org.codehaus.groovy.runtime.typehandling.GroovyCastException
 import org.openqa.selenium.By
 import org.openqa.selenium.WebDriver
 
@@ -192,5 +193,13 @@ class TemplateDerivedPageContent implements Navigator {
             }
             value == o
         }
+    }
+
+    Object asType(Class clazz) {
+        if (_navigator.class in clazz) {
+            return _navigator
+        }
+
+        throw new GroovyCastException(_navigator, clazz)
     }
 }

--- a/module/geb-core/src/test/groovy/geb/ContentUnwrappingSpec.groovy
+++ b/module/geb-core/src/test/groovy/geb/ContentUnwrappingSpec.groovy
@@ -1,0 +1,45 @@
+package geb
+
+import geb.test.GebSpecWithCallbackServer
+import org.codehaus.groovy.runtime.typehandling.GroovyCastException
+
+class ContentUnwrappingSpec extends GebSpecWithCallbackServer {
+
+    def setup() {
+        to PageWithModule
+    }
+
+    def "unwrap module to its declared type"() {
+        when:
+        def module = theModule as DummyModule
+
+        then:
+        module instanceof DummyModule
+    }
+
+    def "unwrap module to its parent type"() {
+        when:
+        def module = theModule as Module
+
+        then:
+        module instanceof Module
+    }
+
+    def "throw relevant exception on unwrap attempt to incorrect type"() {
+        when:
+        def module = theModule as ContentUnwrappingSpec
+
+        then:
+        thrown(GroovyCastException)
+    }
+}
+
+class PageWithModule extends Page {
+
+    static content = {
+        theModule { module(DummyModule) }
+    }
+
+}
+
+class DummyModule extends Module { }


### PR DESCRIPTION
Gives the ability of unwrapping a module to its declared type. This is an improvement which comes as a result of discussion under the issue https://github.com/geb/issues/issues/433

Surely not a final solution yet but leaves the decision to the user: strong module typing or better error messages.