### PR TITLE
Content wrapper can be cast to a delegate type

### DIFF
--- a/doc/manual-snippets/src/test/groovy/modules/UnwrappingModulesSnippetSpec.groovy
+++ b/doc/manual-snippets/src/test/groovy/modules/UnwrappingModulesSnippetSpec.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package modules
+
+import fixture.Browser
+import org.codehaus.groovy.runtime.typehandling.GroovyCastException
+
+class UnwrappingModulesSnippetSpec extends FormContentSpec {
+
+    @SuppressWarnings('UnusedVariable')
+    def "assignment of a module to a variable of its declared type fails"() {
+        when:
+        //tag::module_variable_fail[]
+        Browser.drive {
+            to ModulePage
+            FormModule foo = form   // GroovyCastException is thrown
+        }
+        //end::module_variable_fail[]
+        then:
+        thrown(GroovyCastException)
+    }
+
+    def "method invocation with an argument of module's declared type fails"() {
+        when:
+        //tag::module_argument_fail[]
+        Browser.drive {
+            to ModulePage
+            submitForm(form)   // MissingMethodException is thrown
+        }
+        //end::module_argument_fail[]
+        then:
+        thrown(MissingMethodException)
+    }
+
+    def "unwrapped module may be used with its declared type"() {
+        when:
+        //tag::module_cast[]
+        Browser.drive {
+            to ModulePage
+            FormModule foo = form as FormModule
+            submitForm(foo)
+        }
+        //end::module_cast[]
+        then:
+        noExceptionThrown()
+    }
+
+    //tag::module_argument_fail[]
+
+        void submitForm(FormModule formModule) {
+            formModule.button.click()
+        }
+    //end::module_argument_fail[]
+}

--- a/doc/manual/src/docs/asciidoc/050-modules.adoc
+++ b/doc/manual/src/docs/asciidoc/050-modules.adoc
@@ -402,3 +402,50 @@ It can be used this way…
 ----
 include::{test-dir}/modules/RadioButtonsSnippetSpec.groovy[tag=example,indent=0]
 ----
+
+== Unwrapping modules returned from the `content` DSL
+
+For the sake of better error reporting, current implementation wraps any module declared within `content` block into
+`geb.content.TemplateDerivedPageContent` instance. Thus why the code in following examples won't work.
+
+Given a page defined as follows:
+
+[source,groovy]
+----
+include::{test-dir}/modules/IntroductionSpec.groovy[tag=module_page,indent=0]
+----
+
+A module assignment to a variable of its declared type will fail with `GroovyCastException`:
+
+[source,groovy]
+----
+include::{test-dir}/modules/UnwrappingModulesSnippetSpec.groovy[tag=module_variable_fail,indent=0]
+----
+
+An invocation of a method which takes a module as argument with its declared type will fail with `MissingMethodException`:
+
+[source,groovy]
+----
+include::{test-dir}/modules/UnwrappingModulesSnippetSpec.groovy[tag=module_argument_fail,indent=0]
+----
+
+As you may like or need to use strong typing for modules there is a way to do that. Module can be cast to its declared type with the Groovy `as` operator:
+
+[source,groovy]
+----
+include::{test-dir}/modules/UnwrappingModulesSnippetSpec.groovy[tag=module_cast,indent=0]
+----
+
+[NOTE]
+====
+Bear in mind that casting of a module to its declared type means the module gets unwrapped. By doing so the convenient error messages for such module are gone.
+====
+
+What's the trade-off? Calling `toString()` on any content element, including module, gives a meaningful path like:
+
+[source]
+----
+geb.ModulePage -> form: geb.FormModule -> button: geb.navigator.NonEmptyNavigator
+----
+
+Such paths can be seen in error messages and this is exactly what you are going to give away for unwrapped modules.

--- a/doc/manual/src/docs/asciidoc/140-project.adoc
+++ b/doc/manual/src/docs/asciidoc/140-project.adoc
@@ -66,6 +66,7 @@ Ideas and new features for Geb can be discussed on the link:mailto:geb-dev@googl
 * github-profile:leo-13[Leo Fedorov] - Support for `reportOnTestFailureOnly` config option for Spock integration
 * github-profile:chrisbyrneham[Chris Byrneham] - Ability to specify proxy location and credentials to use with BrowserStack tunnel
 * github-profile:anshbansal[Aseem Bansal] - Doc improvements
+* github-profile:topr[Tomasz Przybysz] - Unwrapping module to its declared type
 
 == History
 

--- a/module/geb-core/src/main/groovy/geb/content/TemplateDerivedPageContent.groovy
+++ b/module/geb-core/src/main/groovy/geb/content/TemplateDerivedPageContent.groovy
@@ -193,4 +193,8 @@ class TemplateDerivedPageContent implements Navigator {
             value == o
         }
     }
+
+    Object asType(Class type) {
+        _navigator.class in type ? _navigator : super.asType(type)
+    }
 }

--- a/module/geb-core/src/test/groovy/geb/ContentUnwrappingSpec.groovy
+++ b/module/geb-core/src/test/groovy/geb/ContentUnwrappingSpec.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package geb
+
+import geb.test.GebSpecWithCallbackServer
+import org.codehaus.groovy.runtime.typehandling.GroovyCastException
+
+class ContentUnwrappingSpec extends GebSpecWithCallbackServer {
+
+    def setup() {
+        to ContentUnwrappingSpecPage
+    }
+
+    def "unwrap module to its declared type"() {
+        when:
+        def module = theModule as ContentUnwrappingSpecModule
+
+        then:
+        module instanceof ContentUnwrappingSpecModule
+    }
+
+    def "unwrap module to its parent type"() {
+        when:
+        def module = theModule as Module
+
+        then:
+        module instanceof Module
+    }
+
+    def "throw relevant exception on unwrap attempt to incorrect type"() {
+        when:
+        theModule as ContentUnwrappingSpec
+
+        then:
+        thrown(GroovyCastException)
+    }
+}
+
+class ContentUnwrappingSpecPage extends Page {
+
+    static content = {
+        theModule { module(ContentUnwrappingSpecModule) }
+    }
+
+}
+
+class ContentUnwrappingSpecModule extends Module { }


### PR DESCRIPTION
Gives the ability of unwrapping a module to its declared type. This is an improvement which comes as a result of discussion under the issue https://github.com/geb/issues/issues/433

Surely not a final solution yet but leaves the decision to the user: strong module typing or better error messages.