### PR TITLE
Move report label creation into its own method so subclasses can generate report labels using the correct test and report numbers

### DIFF
--- a/module/geb-spock/src/main/groovy/geb/spock/GebReportingSpec.groovy
+++ b/module/geb-spock/src/main/groovy/geb/spock/GebReportingSpec.groovy
@@ -56,7 +56,11 @@ class GebReportingSpec extends GebSpec {
     }
 
     void report(String label = "") {
-        browser.report(ReporterSupport.toTestReportLabel(gebReportingSpecTestCounter, gebReportingPerTestCounter++, gebReportingSpecTestName.methodName, label))
+        browser.report(createReportLabel(label))
+    }
+
+    String createReportLabel(String label = "") {
+        ReporterSupport.toTestReportLabel(gebReportingSpecTestCounter, gebReportingPerTestCounter++, gebReportingSpecTestName.methodName, label)
     }
 
 }

--- a/module/geb-spock/src/test/groovy/geb/spock/ReportNameGebSpec.groovy
+++ b/module/geb-spock/src/test/groovy/geb/spock/ReportNameGebSpec.groovy
@@ -1,0 +1,26 @@
+/* Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package geb.spock
+
+class ReportNameGebSpec extends GebReportingSpec {
+    def setup() {
+        config.reportOnTestFailureOnly = true
+    }
+
+    def 'spec subclass can access report label'() {
+        expect:
+        createReportLabel("testing") == '001-001-spec subclass can access report label-testing'
+    }
+}


### PR DESCRIPTION
I'm working on a subclass of `GebReportingSpec` to be able to use multiple browsers in a single Geb test for verifying things like cross-browser WebSocket communication. (https://github.com/craigatk/ratpack-standup/blob/master/src/test/groovy/standup/geb/multi/MultiBrowserGebSpec.groovy)

In my `MultiBrowserGebSpec` sublcass I have multiple `Browser`instances that I want to write reports for, but I can't get access to the `gebReportingSpecTestCounter` and `gebReportingPerTestCounter` fields to create the report label because those fields are private. (https://github.com/craigatk/ratpack-standup/blob/master/src/test/groovy/standup/geb/multi/MultiBrowserGebSpec.groovy#L80)

I suggest moving the report label into its own method so subclasses can generate report labels using the correct test and report numbers. If there is a better way to do this, just let me know. Thanks!
