### PR TITLE
Let gebish.org/manual/ redirect to current manual

### DIFF
--- a/doc/site/src/ratpack/Ratpack.groovy
+++ b/doc/site/src/ratpack/Ratpack.groovy
@@ -33,6 +33,9 @@ ratpack {
         add Date, new Date()
     }
     handlers {
+        get('manual') {
+            redirect("/manual/current")
+        }
         files {
             dir("public")
             indexFiles("index.html")

--- a/doc/site/src/ratpack/Ratpack.groovy
+++ b/doc/site/src/ratpack/Ratpack.groovy
@@ -17,6 +17,7 @@
 
 import geb.site.Manuals
 import ratpack.groovy.template.TextTemplateModule
+import ratpack.handling.Context
 
 import static ratpack.groovy.Groovy.groovyTemplate
 import static ratpack.groovy.Groovy.ratpack
@@ -38,7 +39,7 @@ ratpack {
             indexFiles("index.html")
         }
 
-        get(':page?') { Date startupTime, Manuals manuals ->
+        get(':page?') { Context context, Date startupTime, Manuals manuals ->
             lastModified(startupTime) {
                 def highlightPages = [
                     crossbrowser: "Cross Browser",
@@ -50,15 +51,22 @@ ratpack {
                 ]
 
                 def pageToken = pathTokens.page ?: 'index'
-                def page = pageToken in (highlightPages.keySet() + ['index', 'lists']) ? pageToken : "notfound"
 
-                def model = [
-                    manuals: manuals,
-                    pages  : [Highlights: highlightPages],
-                    page   : page
-                ]
+                String uri = context.request.uri ?: ''
+                if( uri != '/' && uri.endsWith('/') ) {
+                    String redirectTo = uri.substring(0,uri.length()-1)
+                    context.redirect redirectTo
+                } else {
+                    def page = pageToken in (highlightPages.keySet() + ['index', 'lists']) ? pageToken : "notfound"
 
-                render groovyTemplate(model, 'main.html')
+                    def model = [
+                            manuals: manuals,
+                            pages  : [Highlights: highlightPages],
+                            page   : page
+                    ]
+
+                    render groovyTemplate(model, 'main.html')
+                }
             }
         }
     }

--- a/doc/site/src/ratpack/Ratpack.groovy
+++ b/doc/site/src/ratpack/Ratpack.groovy
@@ -65,6 +65,9 @@ ratpack {
                             page   : page
                     ]
 
+                    if( page == "notfound") {
+                        context.response.status(404)
+                    }
                     render groovyTemplate(model, 'main.html')
                 }
             }

--- a/doc/site/src/ratpack/Ratpack.groovy
+++ b/doc/site/src/ratpack/Ratpack.groovy
@@ -33,9 +33,6 @@ ratpack {
         add Date, new Date()
     }
     handlers {
-        get('manual') {
-            redirect("/manual/current")
-        }
         files {
             dir("public")
             indexFiles("index.html")

--- a/doc/site/src/test/groovy/geb/SiteSmokeSpec.groovy
+++ b/doc/site/src/test/groovy/geb/SiteSmokeSpec.groovy
@@ -65,12 +65,15 @@ class SiteSmokeSpec extends GebSpec {
         firstHeaderText == 'What is it?'
     }
 
-    void 'requesting a non-existing page'() {
+    void 'requesting a non-existing page - #pagePath'() {
         when:
-        go('idontexist')
+        go(pagePath)
 
         then:
         at NotFoundPage
+
+        where:
+        pagePath << ['idontexist', 'manuals', 'manuals/']
     }
 
     @Unroll
@@ -83,13 +86,14 @@ class SiteSmokeSpec extends GebSpec {
         firstHeaderText == pageHeader
 
         where:
-        pagePath       | pageHeader
-        'crossbrowser' | 'Cross Browser Automation'
-        'content'      | 'Navigating Content'
-        'pages'        | 'Page Objects'
-        'async'        | 'Asynchronicity'
-        'testing'      | 'Testing'
-        'integration'  | 'Build System Integration'
+        pagePath        | pageHeader
+        'crossbrowser'  | 'Cross Browser Automation'
+        'crossbrowser/' | 'Cross Browser Automation'
+        'content'       | 'Navigating Content'
+        'pages'         | 'Page Objects'
+        'async'         | 'Asynchronicity'
+        'testing'       | 'Testing'
+        'integration'   | 'Build System Integration'
     }
 
     void 'manual and api links are available'() {


### PR DESCRIPTION
A possible fix for https://github.com/geb/issues/issues/415
Instead of a 404, we could let it redirect to the current manual, which seems to be a fair default
