### PR TITLE
Fix small typos in manual

### DIFF
--- a/doc/manual/src/docs/asciidoc/020-browser.adoc
+++ b/doc/manual/src/docs/asciidoc/020-browser.adoc
@@ -241,7 +241,7 @@ Thanks to that you can immediately see evaluated values of your “at checker”
 See the <<at-checker,“at checker”>> section for more details.
 ====
 
-The `to()` method that takes a single page type or instance *verifies* that the the browser ends up at the given page.
+The `to()` method that takes a single page type or instance *verifies* that the browser ends up at the given page.
 If the request may initiate a redirect and take the browser to a different page you should use `{via-method-api}` method:
 
 [source,groovy]

--- a/doc/manual/src/docs/asciidoc/021-driver.adoc
+++ b/doc/manual/src/docs/asciidoc/021-driver.adoc
@@ -29,7 +29,7 @@ This can be done via the methods on the `WebDriver` instance (obtainable via `{b
 
 == Implicit driver management
 
-If a driver is not given when a `Browser` object is constructed, one will be created and managed implicitly by Geb by the the <<driver-implementation-configuration,configuration mechanism>>.
+If a driver is not given when a `Browser` object is constructed, one will be created and managed implicitly by Geb by the <<driver-implementation-configuration,configuration mechanism>>.
 
 [discrete]
 [[implicit-driver-lifecycle]]

--- a/doc/manual/src/docs/asciidoc/040-pages.adoc
+++ b/doc/manual/src/docs/asciidoc/040-pages.adoc
@@ -488,7 +488,7 @@ The `verifyAt()` method call will either:
 
 * return `true` if the “at” checker passes
 * if <<implicit-assertions, implicit assertions>> are <<implicit-assertions-mechanics, enabled>> and the “at” checker fails it will throw an `AssertionError`
-* return `false` if implicit assertions are not enabled and the the “at” checker fails
+* return `false` if implicit assertions are not enabled and the “at” checker fails
 
 Considering the example above you could use it like this…
 

--- a/doc/manual/src/docs/asciidoc/060-configuration.adoc
+++ b/doc/manual/src/docs/asciidoc/060-configuration.adoc
@@ -110,7 +110,7 @@ The name of the driver class to use (it will be constructed with no arguments) c
 include::{test-dir}/configuration/DriverConfigSpec.groovy[tag=configuring_driver_using_class_name,indent=0]
 ----
 
-Or it can be one of the following short names: `ie`, `htmlunit`, `firefox` or `chrome`. These will be implicitly expanded to their fully qualified class names…
+Or it can be one of the following short names: `ie`, `htmlunit`, `firefox`, `chrome` or `edge`. These will be implicitly expanded to their fully qualified class names…
 
 [source,groovy]
 ----

--- a/doc/manual/src/docs/asciidoc/080-javascript.adoc
+++ b/doc/manual/src/docs/asciidoc/080-javascript.adoc
@@ -296,7 +296,7 @@ include::{core-source-dir}/geb/js/AlertAndConfirmSupport.groovy[tag=confirm,inde
 
 The first method, `withConfirm()` (and its ‘`ok`’ defaulted relative), is used to verify actions that will produce a confirm dialog.
 This method returns the confirmation message.
-The `ok` parameter controls whether the the “OK” or “Cancel” button should be clicked.
+The `ok` parameter controls whether the “OK” or “Cancel” button should be clicked.
 
 Given the following HTML…
 

--- a/doc/manual/src/docs/asciidoc/100-reporting.adoc
+++ b/doc/manual/src/docs/asciidoc/100-reporting.adoc
@@ -48,8 +48,8 @@ We have now created the following files inside the `reportsDir`…
 
 * `google/home page.html`
 * `google/home page.png`
-* `wikipedia/home page.html`
-* `wikipedia/home page.png`
+* `gebish/home page.html`
+* `gebish/home page.png`
 
 The browser will create the directory for the report group as needed.
 By default, the report group is not set which means that reports are written to the base of the `reportsDir`.


### PR DESCRIPTION
Fixes 4 small typos and updates a reference to sample code which previously used wikipedia to the correct gebish