### PR TITLE
Fix Gradle build integration example in manual

### DIFF
--- a/doc/manual/src/docs/asciidoc/120-build-integrations.adoc
+++ b/doc/manual/src/docs/asciidoc/120-build-integrations.adoc
@@ -18,23 +18,25 @@ repositories {
     mavenCentral()
 }
 
-dependencies {
-    groovy "org.codehaus.groovy:groovy-all:{groovy-version}"
+ext {
+    gebVersion = "{geb-version}"
+    seleniumVersion = "{selenium-version}"
+}
 
-    def gebVersion = "{geb-version}"
-    def seleniumVersion = "{selenium-version}"
+dependencies {
+    compile "org.codehaus.groovy:groovy-all:{groovy-version}"
 
     // If using Spock, need to depend on geb-spock
-    testCompile "{geb-group}:geb-spock:$\{geb-version\}"
+    testCompile "{geb-group}:geb-spock:$\{gebVersion\}"
     testCompile "org.spockframework:spock-core:{spock-core-version}"
 
     // If using JUnit, need to depend on geb-junit (3 or 4)
-    testCompile "{geb-group}:geb-junit4:$\{geb-version\}"
+    testCompile "{geb-group}:geb-junit4:$\{gebVersion\}"
     testCompile "junit:junit-dep:4.8.2"
 
     // Need a driver implementation
-    testCompile "org.seleniumhq.selenium:selenium-firefox-driver:$\{selenium-version\}"
-    testRuntime "org.seleniumhq.selenium:selenium-support:$\{selenium-version\}"
+    testCompile "org.seleniumhq.selenium:selenium-firefox-driver:$\{seleniumVersion\}"
+    testRuntime "org.seleniumhq.selenium:selenium-support:$\{seleniumVersion\}"
 }
 
 test {


### PR DESCRIPTION
The old example didn't work with the latest stable version of Gradle (4.4.1 at the time of writing).

This change set makes the minimum amount of changes to make it work with Gradle 4.4.1.

Gradle version:

```
$ gradle -v

------------------------------------------------------------
Gradle 4.4.1
------------------------------------------------------------

Build time:   2017-12-20 15:45:23 UTC
Revision:     10ed9dc355dc39f6307cc98fbd8cea314bdd381c

Groovy:       2.4.12
Ant:          Apache Ant(TM) version 1.9.9 compiled on February 2 2017
JVM:          1.8.0_151 (Oracle Corporation 25.151-b12)
OS:           Mac OS X 10.13.2 x86_64
```

Failing example:

```
$ gradle build

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/joschi/foobar/build.gradle' line: 8

* What went wrong:
A problem occurred evaluating root project 'foobar'.
> Could not find method groovy() for arguments [org.codehaus.groovy:groovy-all:2.4.7] on object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 0s
```

Successful example:

```
$ gradle build

BUILD SUCCESSFUL in 0s
1 actionable task: 1 executed
```