### PR TITLE
Add week input module

### DIFF
--- a/doc/manual-snippets/src/realBrowserTest/groovy/modules/WeekInputSnippetSpec.groovy
+++ b/doc/manual-snippets/src/realBrowserTest/groovy/modules/WeekInputSnippetSpec.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package modules
+
+import geb.module.WeekInput
+import geb.test.GebSpecWithCallbackServer
+import org.threeten.extra.YearWeek
+
+class WeekInputSnippetSpec extends GebSpecWithCallbackServer {
+
+    def "using week input module"() {
+        given:
+        html """
+            // tag::html[]
+            <html>
+                <body>
+                    <input type="week" name="delivery-week" min="2018-W01" max="2019-W01" step="1" />
+                </body>
+            </html>
+            // end::html[]
+        """
+        // tag::example_week[]
+        def input = $(name: "start").module(WeekInput)
+
+        // end::example_week[]
+        when:
+        // tag::example_week[]
+        input.week = YearWeek.of(2018, 5)
+
+        // end::example_week[]
+        then:
+        // tag::example_week[]
+        assert input.week == YearWeek.of(2018, 5)
+
+        // end::example_week[]
+        when:
+        // tag::example_string[]
+        input.week = "2018-W52"
+
+        // end::example_string[]
+        then:
+        // tag::example_string[]
+        assert input.time == YearWeek.of(2018, 52)
+        // end::example_string[]
+    }
+
+}

--- a/doc/manual/src/docs/asciidoc/050-modules.adoc
+++ b/doc/manual/src/docs/asciidoc/050-modules.adoc
@@ -482,6 +482,31 @@ include::{real-browser-test-dir}/modules/TimeInputSnippetSpec.groovy[tag=example
 include::{real-browser-test-dir}/modules/TimeInputSnippetSpec.groovy[tag=example_string,indent=0]
 ----
 
+=== `WeekInput`
+
+The `{week-input-api}` module provides property methods for setting and retrieving the week of a week input element.
+
+Given the html…
+
+[source,html]
+----
+include::{real-browser-test-dir}/modules/WeekInputSnippetSpec.groovy[tag=html,indent=0]
+----
+
+It can be used either with a `org.threeten.extra.YearWeek` object…
+
+[source,groovy]
+----
+include::{real-browser-test-dir}/modules/WeekInputSnippetSpec.groovy[tag=example_week,indent=0]
+----
+
+…or with a string…
+
+[source,groovy]
+----
+include::{real-browser-test-dir}/modules/WeekInputSnippetSpec.groovy[tag=example_string,indent=0]
+----
+
 === `EmailInput`
 
 The `{email-input-api}` module provides property methods for setting and retrieving text of an email input element.

--- a/doc/manual/src/docs/asciidoc/140-project.adoc
+++ b/doc/manual/src/docs/asciidoc/140-project.adoc
@@ -89,6 +89,7 @@ This page lists the high level changes between versions of Geb.
 * Added form control module for color inputs. [issue:549[]]
 * Added form control module for datetime-local inputs. [issue:550[]]
 * Added form control module for time inputs. [issue:554[]]
+* Added form control module for week inputs. [issue:553[]]
 
 === 2.2
 

--- a/doc/manual/src/docs/asciidoc/_links.adoc
+++ b/doc/manual/src/docs/asciidoc/_links.adoc
@@ -100,6 +100,7 @@
 :date-input-api: link:api/geb/module/DateInput.html[DateInput]
 :datetime-local-input-api: link:api/geb/module/DateTimeLocalInput.html[DateTimeLocalInput]
 :time-input-api: link:api/geb/module/TimeInput.html[TimeInput]
+:week-input-api: link:api/geb/module/WeekInput.html[WeekInput]
 :email-input-api: link:api/geb/module/EmailInput.html[EmailInput]
 :tel-input-api: link:api/geb/module/TelInput.html[TelInput]
 :number-input-api: link:api/geb/module/NumberInput.html[NumberInput]

--- a/module/geb-core/geb-core.gradle
+++ b/module/geb-core/geb-core.gradle
@@ -22,6 +22,7 @@ dependencies {
     compile project(":module:geb-ast")
     compile project(":module:geb-waiting")
     compile 'org.jodd:jodd-lagarto:3.7.1'
+    compile'org.threeten:threeten-extra:1.4'
 
     testCompile "cglib:cglib:2.2", jsoupDependency, ratpack.groovyTest
 }

--- a/module/geb-core/src/main/groovy/geb/module/WeekInput.groovy
+++ b/module/geb-core/src/main/groovy/geb/module/WeekInput.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package geb.module
+
+import org.threeten.extra.YearWeek
+
+class WeekInput extends AbstractInput {
+
+    final String inputType = "week"
+
+    void setWeek(YearWeek week) {
+        value(week.toString())
+    }
+
+    void setWeek(String iso8601FormattedWeek) {
+        value(iso8601FormattedWeek)
+    }
+
+    YearWeek getWeek() {
+        parseWeek(value() as String)
+    }
+
+    YearWeek getMin() {
+        parseWeek(attr("min"))
+    }
+
+    YearWeek getMax() {
+        parseWeek(attr("max"))
+    }
+
+    Integer getStep() {
+        attr("step")?.toInteger()
+    }
+
+    private YearWeek parseWeek(String string) {
+        if (string == null || string.empty) {
+            return null
+        }
+        YearWeek.parse(string)
+    }
+
+    @Override
+    protected boolean isTypeValid(String type) {
+        super.isTypeValid(type) || type == "text"
+    }
+
+}

--- a/module/geb-core/src/test/groovy/geb/module/WeekInputBaseSpec.groovy
+++ b/module/geb-core/src/test/groovy/geb/module/WeekInputBaseSpec.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package geb.module
+
+class WeekInputBaseSpec extends InputBasedModuleSpec<WeekInput> {
+    final String inputType = 'week'
+    final String otherInputType = 'checkbox'
+}

--- a/module/geb-core/src/test/groovy/geb/module/WeekInputSpec.groovy
+++ b/module/geb-core/src/test/groovy/geb/module/WeekInputSpec.groovy
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package geb.module
+
+import geb.test.GebSpecWithCallbackServer
+import geb.test.browsers.Chrome
+import geb.test.browsers.Firefox
+import geb.test.browsers.RequiresRealBrowser
+import org.threeten.extra.YearWeek
+
+@Chrome
+@Firefox
+@RequiresRealBrowser // maybe due to https://sourceforge.net/p/htmlunit/bugs/1923/
+class WeekInputSpec extends GebSpecWithCallbackServer {
+
+    def setup() {
+        html {
+            input(type: 'week', min: '2018-W01', max: '2019-W01', step: '1')
+        }
+    }
+
+    WeekInput getInput() {
+        $("input").module(WeekInput)
+    }
+
+    def 'unset'() {
+        expect:
+        input.week == null
+    }
+
+    def 'setting using week'() {
+        when:
+        input.week = week
+
+        then:
+        input.week == week
+
+        where:
+        week = YearWeek.of(2018, 9)
+    }
+
+    def 'setting using ISO 8601 string'() {
+        when:
+        input.week = week.toString()
+
+        then:
+        input.week == week
+
+        where:
+        week = YearWeek.of(2018, 10)
+    }
+
+    def 'updating'() {
+        when:
+        input.week = week
+
+        and:
+        input.week = week.plusWeeks(1)
+
+        then:
+        input.week == week.plusWeeks(1)
+
+        where:
+        week = YearWeek.of(2018, 11)
+    }
+
+    def 'get min, max and step'() {
+        expect:
+        input.min == YearWeek.of(2018, 1)
+
+        and:
+        input.max == YearWeek.of(2019, 1)
+
+        and:
+        input.step == 1
+    }
+
+}


### PR DESCRIPTION
For the lag of a java.time.YearWeek, the current implementation uses
org.threeten.extra.YearWeek.

See
https://www.w3.org/TR/2017/REC-html52-20171214/sec-forms.html#week-state-typeweek

Contributes to geb/issues#553