### PR TITLE
Use Number instead of Double in Wait

### DIFF
--- a/doc/manual/src/docs/asciidoc/140-project.adoc
+++ b/doc/manual/src/docs/asciidoc/140-project.adoc
@@ -86,7 +86,7 @@ This page lists the high level changes between versions of Geb.
 
 === {geb-version}
 
-No changes have been made, yet.
+* Use `Number` instead of `Double` for waitFor calls [issue:570[]]
 
 === 2.3.1
 

--- a/module/geb-core/src/main/groovy/geb/Configuration.groovy
+++ b/module/geb-core/src/main/groovy/geb/Configuration.groovy
@@ -48,7 +48,7 @@ class Configuration {
     /**
      * Updates a {@code waiting.preset} config entry for a given preset name.
      */
-    void setWaitPreset(String name, Double presetTimeout, Double presetRetryInterval) {
+    void setWaitPreset(String name, Number presetTimeout, Number presetRetryInterval) {
         rawConfig.waiting.presets[name].with {
             timeout = presetTimeout
             retryInterval = presetRetryInterval
@@ -67,7 +67,7 @@ class Configuration {
         new Wait(getDefaultWaitTimeout(), getDefaultWaitRetryInterval(), getIncludeCauseInWaitTimeoutExceptionMessage())
     }
 
-    Wait getWait(Double timeout) {
+    Wait getWait(Number timeout) {
         new Wait(timeout, getDefaultWaitRetryInterval(), getIncludeCauseInWaitTimeoutExceptionMessage())
     }
 
@@ -77,14 +77,14 @@ class Configuration {
         } else if (waitingParam instanceof CharSequence) {
             getWaitPreset(waitingParam.toString())
         } else if (waitingParam instanceof Number && waitingParam > 0) {
-            getWait(waitingParam.doubleValue())
+            getWait(waitingParam)
         } else if (waitingParam instanceof Collection) {
             if (waitingParam.size() == 2) {
                 def timeout = waitingParam[0]
                 def retryInterval = waitingParam[1]
 
                 if (timeout instanceof Number && retryInterval instanceof Number) {
-                    new Wait(timeout.doubleValue(), retryInterval.doubleValue(), getIncludeCauseInWaitTimeoutExceptionMessage())
+                    new Wait(timeout, retryInterval, getIncludeCauseInWaitTimeoutExceptionMessage())
                 } else {
                     throw new IllegalArgumentException("'wait' param has illegal value '$waitingParam' (collection elements must be numbers)")
                 }
@@ -101,7 +101,7 @@ class Configuration {
      *
      * @see #getDefaultWaitTimeout()
      */
-    void setDefaultWaitTimeout(Double defaultWaitTimeout) {
+    void setDefaultWaitTimeout(Number defaultWaitTimeout) {
         rawConfig.waiting.timeout = defaultWaitTimeout
     }
 
@@ -110,8 +110,8 @@ class Configuration {
      * <p>
      * Either the value at config path {@code waiting.timeout} or {@link geb.waiting.Wait#DEFAULT_TIMEOUT 5}.
      */
-    Double getDefaultWaitTimeout() {
-        readValue(rawConfig.waiting, 'timeout', Wait.DEFAULT_TIMEOUT)
+    Number getDefaultWaitTimeout() {
+        readValue(rawConfig.waiting, 'timeout', Wait.DEFAULT_TIMEOUT) as Number
     }
 
     /**
@@ -137,7 +137,7 @@ class Configuration {
      *
      * @see #getDefaultWaitRetryInterval()
      */
-    void setDefaultWaitRetryInterval(Double defaultWaitRetryInterval) {
+    void setDefaultWaitRetryInterval(Number defaultWaitRetryInterval) {
         rawConfig.waiting.retryInterval = defaultWaitRetryInterval
     }
 
@@ -146,7 +146,7 @@ class Configuration {
      * <p>
      * Either the value at config path {@code waiting.retryInterval} or {@link geb.waiting.Wait#DEFAULT_RETRY_INTERVAL 0.1}.
      */
-    Double getDefaultWaitRetryInterval() {
+    Number getDefaultWaitRetryInterval() {
         readValue(rawConfig.waiting, 'retryInterval', Wait.DEFAULT_RETRY_INTERVAL)
     }
 

--- a/module/geb-core/src/main/groovy/geb/Module.groovy
+++ b/module/geb-core/src/main/groovy/geb/Module.groovy
@@ -733,12 +733,12 @@ class Module implements Navigator, PageContentContainer, Initializable, WaitingS
     }
 
     @Override
-    def <T> T waitFor(Map params = [:], Double timeout, Closure<T> block) {
+    def <T> T waitFor(Map params = [:], Number timeout, Closure<T> block) {
         waitingSupport.waitFor(params, timeout, block)
     }
 
     @Override
-    def <T> T waitFor(Map params = [:], Double timeout, Double interval, Closure<T> block) {
+    def <T> T waitFor(Map params = [:], Number timeout, Number interval, Closure<T> block) {
         waitingSupport.waitFor(params, timeout, interval, block)
     }
 

--- a/module/geb-core/src/main/groovy/geb/Page.groovy
+++ b/module/geb-core/src/main/groovy/geb/Page.groovy
@@ -439,7 +439,7 @@ class Page implements Navigable, PageContentContainer, Initializable, WaitingSup
      * @return the true-ish return value from {@code block}
      * @throws {@link geb.waiting.WaitTimeoutException} if the block does not produce a true-ish value in time
      */
-    public <T> T refreshWaitFor(Map params = [:], Double timeout, Closure<T> block) {
+    public <T> T refreshWaitFor(Map params = [:], Number timeout, Closure<T> block) {
         waitingSupport.waitFor(params, timeout, withRefresh(block))
     }
 
@@ -454,7 +454,7 @@ class Page implements Navigable, PageContentContainer, Initializable, WaitingSup
      * @return the true-ish return value from {@code block}
      * @throws {@link geb.waiting.WaitTimeoutException} if the block does not produce a true-ish value in time
      */
-    public <T> T refreshWaitFor(Map params = [:], Double timeout, Double interval, Closure<T> block) {
+    public <T> T refreshWaitFor(Map params = [:], Number timeout, Number interval, Closure<T> block) {
         waitingSupport.waitFor(params, timeout, interval, withRefresh(block))
     }
 

--- a/module/geb-core/src/main/groovy/geb/waiting/DefaultWaitingSupport.groovy
+++ b/module/geb-core/src/main/groovy/geb/waiting/DefaultWaitingSupport.groovy
@@ -37,11 +37,11 @@ class DefaultWaitingSupport implements WaitingSupport {
         doWaitFor(params.message, config.defaultWait, block)
     }
 
-    public <T> T waitFor(Map params = [:], Double timeout, Closure<T> block) {
+    public <T> T waitFor(Map params = [:], Number timeout, Closure<T> block) {
         doWaitFor(params.message, config.getWait(timeout), block)
     }
 
-    public <T> T waitFor(Map params = [:], Double timeout, Double interval, Closure<T> block) {
+    public <T> T waitFor(Map params = [:], Number timeout, Number interval, Closure<T> block) {
         doWaitFor(params.message, new Wait(timeout, interval), block)
     }
 

--- a/module/geb-core/src/main/groovy/geb/waiting/UninitializedWaitingSupport.groovy
+++ b/module/geb-core/src/main/groovy/geb/waiting/UninitializedWaitingSupport.groovy
@@ -35,12 +35,12 @@ class UninitializedWaitingSupport implements WaitingSupport {
     }
 
     @Override
-    def <T> T waitFor(Map params = [:], Double timeout, Closure<T> block) {
+    def <T> T waitFor(Map params = [:], Number timeout, Closure<T> block) {
         throw initializable.uninitializedException()
     }
 
     @Override
-    def <T> T waitFor(Map params = [:], Double timeout, Double interval, Closure<T> block) {
+    def <T> T waitFor(Map params = [:], Number timeout, Number interval, Closure<T> block) {
         throw initializable.uninitializedException()
     }
 }

--- a/module/geb-core/src/main/groovy/geb/waiting/WaitingSupport.groovy
+++ b/module/geb-core/src/main/groovy/geb/waiting/WaitingSupport.groovy
@@ -53,9 +53,9 @@ interface WaitingSupport {
      * @return the true-ish return value from {@code block}
      * @throws {@link geb.waiting.WaitTimeoutException} if the block does not produce a true-ish value in time
      */
-    public <T> T waitFor(Double timeout, Closure<T> block)
+    public <T> T waitFor(Number timeout, Closure<T> block)
 
-    public <T> T waitFor(Map params, Double timeout, Closure<T> block)
+    public <T> T waitFor(Map params, Number timeout, Closure<T> block)
 
     /**
      * Invokes {@code block} every {@code interval} seconds, until it returns
@@ -67,8 +67,8 @@ interface WaitingSupport {
      * @return the true-ish return value from {@code block}
      * @throws {@link geb.waiting.WaitTimeoutException} if the block does not produce a true-ish value in time
      */
-    public <T> T waitFor(Double timeout, Double interval, Closure<T> block)
+    public <T> T waitFor(Number timeout, Number interval, Closure<T> block)
 
-    public <T> T waitFor(Map params, Double timeout, Double interval, Closure<T> block)
+    public <T> T waitFor(Map params, Number timeout, Number interval, Closure<T> block)
 
 }

--- a/module/geb-waiting/src/main/groovy/geb/waiting/Wait.groovy
+++ b/module/geb-waiting/src/main/groovy/geb/waiting/Wait.groovy
@@ -26,24 +26,24 @@ class Wait {
     /**
      * 5 seconds
      */
-    static public final Double DEFAULT_TIMEOUT = 5
+    static public final Number DEFAULT_TIMEOUT = 5
 
     /**
      * 100 milliseconds
      */
-    static public final Double DEFAULT_RETRY_INTERVAL = 0.1
+    static public final Number DEFAULT_RETRY_INTERVAL = 0.1
 
     private static final int HASHCODE_MULTIPLIER = 31
 
     /**
      * The maximum amount of seconds that something can be waited on.
      */
-    final Double timeout
+    final Number timeout
 
     /**
      * How many seconds to wait before trying something again while waiting.
      */
-    final Double retryInterval
+    final Number retryInterval
 
     /**
      * Whether we should append cause strings to the returned exception message or not
@@ -52,7 +52,7 @@ class Wait {
 
     String customMessage
 
-    Wait(Double timeout = DEFAULT_TIMEOUT, Double retryInterval = DEFAULT_RETRY_INTERVAL, boolean includeCauseInExceptionMessage = false) {
+    Wait(Number timeout = DEFAULT_TIMEOUT, Number retryInterval = DEFAULT_RETRY_INTERVAL, boolean includeCauseInExceptionMessage = false) {
         this.timeout = timeout
         this.retryInterval = [timeout, retryInterval].min()
         this.includeCauseInExceptionMessage = includeCauseInExceptionMessage
@@ -87,7 +87,7 @@ class Wait {
     Date calculateTimeoutFrom(Date start) {
         def calendar = Calendar.instance
         calendar.time = start
-        calendar.add(Calendar.MILLISECOND, Math.ceil(toMiliseconds(timeout)) as int)
+        calendar.add(Calendar.MILLISECOND, Math.ceil(toMilliseconds(timeout)) as int)
         calendar.time
     }
 
@@ -141,10 +141,10 @@ class Wait {
      * Blocks the caller for the retryInterval
      */
     void sleepForRetryInterval() {
-        Thread.sleep(toMiliseconds(retryInterval) as long)
+        Thread.sleep(toMilliseconds(retryInterval) as long)
     }
 
-    private double toMiliseconds(Double seconds) {
+    private static double toMilliseconds(Number seconds) {
         seconds * 1000
     }
 }

--- a/module/geb-waiting/src/main/groovy/geb/waiting/Wait.groovy
+++ b/module/geb-waiting/src/main/groovy/geb/waiting/Wait.groovy
@@ -87,7 +87,7 @@ class Wait {
     Date calculateTimeoutFrom(Date start) {
         def calendar = Calendar.instance
         calendar.time = start
-        calendar.add(Calendar.MILLISECOND, Math.ceil(toMilliseconds(timeout)) as int)
+        calendar.add(Calendar.MILLISECOND, toMilliseconds(timeout))
         calendar.time
     }
 
@@ -141,10 +141,10 @@ class Wait {
      * Blocks the caller for the retryInterval
      */
     void sleepForRetryInterval() {
-        Thread.sleep(toMilliseconds(retryInterval) as long)
+        Thread.sleep(toMilliseconds(retryInterval))
     }
 
-    private static double toMilliseconds(Number seconds) {
+    private static int toMilliseconds(Number seconds) {
         seconds * 1000
     }
 }


### PR DESCRIPTION
There is no reason to restrict timeout and interval to Double values.
In the documentation there never was any example using Double, but
Integer (e.g. 5) or Float (e.g. 0.1). While the calls actually worked
due to Groovy's dynamic typing, they cause errors when using strict
typing and cause irritations in Idea, which cannot find the right
method and assumes that waitFor will return Object instead of the return
type of the given Closure.

Switching to Number allows to use any Number type and will solve these
issues.

Contributes to geb/issues#570