### PR TITLE
Replace link to old selenium wiki in 010-intro.adoc

### DIFF
--- a/doc/manual/src/docs/asciidoc/010-intro.adoc
+++ b/doc/manual/src/docs/asciidoc/010-intro.adoc
@@ -19,7 +19,7 @@ For more information see the manual section on link:#driver[using a driver imple
 == The Page Object pattern
 
 The Page Object Pattern gives us a common sense way to model content in a reusable and maintainable way.
-From the link:http://code.google.com/p/selenium/wiki/PageObjects[WebDriver wiki page on the Page Object Pattern]:
+From the link:https://github.com/SeleniumHQ/selenium/wiki/PageObjects[WebDriver wiki page on the Page Object Pattern]:
 
 ____
 

--- a/doc/manual/src/docs/asciidoc/140-project.adoc
+++ b/doc/manual/src/docs/asciidoc/140-project.adoc
@@ -77,6 +77,7 @@ Ideas and new features for Geb can be discussed on the link:mailto:geb-dev@googl
 * github-profile:joschi[Jochen Schalanda] - Doc
 * github-profile:mkutz[Michael Kutz] - Addition of `{number-input-api}`, `{range-input-api}`, `{url-input-api}`, `{password-input-api}`, `{color-input-api}`, `{datetime-local-input-api}`, `{time-input-api}`, `{month-input-api}` and `{week-input-api}`
 * github-profile:kriegaex[Alexander Kriegisch] - Doc fixes
+* github-profile:topperfalkon[Harley Faggetter] - Doc fixes
 
 == History
 


### PR DESCRIPTION
Selenium wiki was migrated from google code to github, so the link redirects, but not to the correct page. I've replaced the link with a direct link to the corresponding page on the github wiki