### PR TITLE
Added pom type for groovy-all dependency in manual

### DIFF
--- a/doc/manual/src/docs/asciidoc/120-build-integrations.adoc
+++ b/doc/manual/src/docs/asciidoc/120-build-integrations.adoc
@@ -70,6 +70,7 @@ Below is a valid `pom.xml` file for working with Geb for testing (with Spock).
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-all</artifactId>
       <version>{groovy-version}</version>
+      <type>pom</type>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
No longer downloads as a jar, so addition of pom type necessary.