### PR TITLE
create geb-lambdatest plugin to support geb framework

### DIFF
--- a/doc/manual/src/docs/asciidoc/111-cloud-browsers.adoc
+++ b/doc/manual/src/docs/asciidoc/111-cloud-browsers.adoc
@@ -2,17 +2,17 @@
 
 When you want to perform web testing on multiple browsers and operating systems, it can be quite complicated to maintain machines for each of the target environments.
 There are a few companies that provide "remote web browsers as a service", making it easy to do this sort of matrix testing without having to maintain the multiple browser installations yourself.
-Geb provides easy integration with two such services, link:https://saucelabs.com/[SauceLabs] and link:http://www.browserstack.com/[BrowserStack].
+Geb provides easy integration with three such services, link:https://saucelabs.com/[SauceLabs], link:https://lambdatest.com/[LambdaTest] and link:http://www.browserstack.com/[BrowserStack].
 This integration includes two parts: assistance with creating a driver in `GebConfig.groovy` and a Gradle plugin.
 
 == Creating a driver
 
-For both SauceLabs and BrowserStack, a special driver factory is provided that, given a browser specification as well as an username and access key, creates an instance of `RemoteWebDriver` configured
+For all three SauceLabs, LambdaTest and BrowserStack, a special driver factory is provided that, given a browser specification as well as an username and access key, creates an instance of `RemoteWebDriver` configured
 to use a browser in the cloud.
 Examples of typical usage in `GebConfig.groovy` are included below.
-They will configure Geb to run in SauceLabs/BrowserStack if the appropriate system property is set, and if not it will use whatever driver that is configured.
+They will configure Geb to run in SauceLabs/LambdaTest/BrowserStack if the appropriate system property is set, and if not it will use whatever driver that is configured.
 This is useful if you want to run the code in a local browser for development.
-In theory you could use any system property to pass the browser specification but `geb.saucelabs.browser`/`geb.browserstack.browser` are also used by the Geb Gradle plugins, so it's a good idea to
+In theory you could use any system property to pass the browser specification but `geb.saucelabs.browser`/`geb.lambdatest.browser`/`geb.browserstack.browser` are also used by the Geb Gradle plugins, so it's a good idea to
 stick with those property names.
 
 The first parameter passed to the `create()` method is a ”browser specification“ and it should be a list of required browser capabilities in Java properties file format:
@@ -49,9 +49,10 @@ platform=MAC
 as the ”browser specification“. For a full list of available browsers, versions and operating systems refer to your cloud provider's documentation:
 
 * link:https://saucelabs.com/platforms[SauceLabs platform list]
+* link:https://www.lambdatest.com/list-of-browsers[LambdaTest platform and browser list]
 * link:http://www.browserstack.com/list-of-browsers-and-platforms?product=automate[BrowserStack Browsers and Platforms list]
 
-Please note that Geb Gradle plugins can set the `geb.saucelabs.browser`/`geb.browserstack.browser` system properties for you using the aforementioned format.
+Please note that Geb Gradle plugins can set the `geb.saucelabs.browser`/`geb.lambdatest.browser`/`geb.browserstack.browser` system properties for you using the aforementioned format.
 
 Following the browser specification are the username and access key used to identify your account with the cloud provider.
 The example uses two environment variables to access this information.
@@ -63,6 +64,7 @@ The configuration options available are described in your cloud provider's docum
 
 * link:https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options[SauceLabs additional config]
 * link:http://www.browserstack.com/automate/capabilities[BrowserStack Capabilities]
+* link:https://www.lambdatest.com/capabilities-generator/[LambdaTest capabilities]
 
 Finally, there is also link:api/geb/driver/CloudDriverFactory.html#create(java.lang.String,%20java.lang.String,%20Map%3CString,%20Object%3E)[an overloaded version of `create()` method] available that
 doesn't take a string specification and allows you to simply specify all the required capabilities using a map.
@@ -133,12 +135,50 @@ if (browserStackBrowser) {
 }
 ----
 
+
+[[lambda-test-driver-factory]]
+=== `LambdaTestDriverFactory`
+
+The following is an example of utilizing `LambdaTestDriverFactory` in `GebConfig.groovy` to configure a driver that will use a browser provided in the LambdaTest cloud.
+
+[source,groovy]
+----
+def lambdaTestBrowser = System.getProperty("geb.lambdatest.browser")
+if (lambdaTestBrowser) {
+    driver = {
+       def username = System.getenv("GEB_LAMBDATEST_USERNAME")
+       assert username
+       def accessKey = System.getenv("GEB_LAMBDATEST_AUTHKEY")
+       assert accessKey
+       new LambdaTestDriverFactory().create(lambdaTestBrowser, username, accessKey)
+    }
+}
+----
+
+If using `TunnelIdentifier` support:
+
+[source,groovy]
+----
+def lambdaTestBrowser = System.getProperty("geb.lambdatest.browser")
+if (lambdaTestBrowser) {
+    driver = {
+       def username = System.getenv("GEB_LAMBDATEST_USERNAME")
+       assert username
+       def accessKey = System.getenv("GEB_LAMBDATEST_AUTHKEY")
+       assert accessKey
+       def tunnelId = System.getenv("GEB_LAMBDATEST_TUNNELID")
+       assert localId
+       new LambdaTestDriverFactory().create(lambdaTestBrowser, username, accessKey, tunnelId)
+    }
+}
+----
+
 == Gradle plugins
 
-For both SauceLabs and BrowserStack, Geb provides a Gradle plugin which simplifies declaring the account and browsers that are desired, as well as configuring a tunnel to allow the cloud provider to
+For SauceLabs, LambdaTest and BrowserStack, Geb provides a Gradle plugin which simplifies declaring the account and browsers that are desired, as well as configuring a tunnel to allow the cloud provider to
 access local applications.
-These plugins allow easily creating multiple `Test` tasks that will have the appropriate `geb.PROVIDER.browser` property set (where _PROVIDER_ is either `saucelabs` or `browserstack`).
-The value of that property can be then passed in configuration file to <<sauce-labs-driver-factory>>/<<browser-stack-driver-factory>> as the ”browser specification“.
+These plugins allow easily creating multiple `Test` tasks that will have the appropriate `geb.PROVIDER.browser` property set (where _PROVIDER_ is either `saucelabs`, `lambdatest` or `browserstack`).
+The value of that property can be then passed in configuration file to <<sauce-labs-driver-factory>>/<<lambda-test-driver-factory>>/<<browser-stack-driver-factory>> as the ”browser specification“.
 Examples of typical usage are included below.
 
 === geb-saucelabs plugin
@@ -334,3 +374,78 @@ browserStack {
 ----
 
 :numbered:
+
+
+=== geb-lambdatest plugin
+
+Following is an example of using the geb-lambdatest Gradle plugin.
+
+[source,groovy,subs="attributes,verbatim"]
+----
+import geb.gradle.lambdatest.LambdaTestAccount
+
+apply plugin: "geb-lambdatest" //<1>
+
+buildscript { //<2>
+    repositories {
+       mavenCentral()
+    }
+    dependencies {
+       classpath 'org.gebish:geb-gradle:{geb-version}'
+    }
+}
+
+lambdaTest {
+    application 'http://localhost:8080' //<3>
+    browsers { //<4>
+        chrome_windows_70 {
+                   capabilities platform: "Windows 10"
+               }
+    }
+    task { //<6>
+       testClassesDir = test.testClassesDir
+       testSrcDirs = test.testSrcDirs
+       classpath = test.classpath
+    }
+    account { //<7>
+       username = System.getenv(LambdaTestAccount.USER_ENV_VAR)
+       accessKey = System.getenv(LambdaTestAccount.ACCESS_KEY_ENV_VAR)
+    }
+    tunnelOps {
+        additionalOptions = ['--proxy', 'proxy.example.com:8080'] //<8>
+    }
+}
+----
+<1> Apply the plugin to the build.
+<2> Specify how to resolve the plugin.
+<3> Specify which urls the LambdaTest Tunnel should be able to access.
+Multiple applications can be specified.
+If no applications are specified, the tunnel will not be restricted to particular URLs.
+<4> The tests would run in chrome on Windows 10 as sample.
+<5> Explicitly specify the required browser capabilities if the shorthand syntax doesn't allow you to express all needed capabilities.
+<6> Configure all of the generated test tasks; for each of them the closure is run with delegate set to a test task being configured.
+<7> Pass credentials for LambdaTest.
+<8> Pass additional link:https://www.lambdatest.com/support/docs/lambda-tunnel-modifiers/[command line options] to LambdaTestTunnel.
+
+
+[TIP]
+====
+You can use `allLambdaTestTests` task that will depend on all of the generated test tasks to run all of them during a build.
+====
+
+:numbered!:
+
+==== Disabling LambdaTest Tunnel
+
+The plugin by default manages the lifecycle of a tunnel which allows to point the browsers provisioned at LambdaTest at urls which are accessible from localhost but not from the Internet.
+
+If you are pointing the browsers only at urls which are accessible on the Internet and wish to get rid of the overhead associated with opening the tunnel you might want to disable the use of it.
+It can be done in the following way:
+
+[source,groovy,subs="attributes,verbatim"]
+----
+lambdaTest {
+    useTunnel = false
+}
+----
+

--- a/integration/geb-gradle/geb-gradle.gradle
+++ b/integration/geb-gradle/geb-gradle.gradle
@@ -35,5 +35,9 @@ gradlePlugin {
             id = 'geb-browserstack'
             implementationClass = 'geb.gradle.browserstack.BrowserStackPlugin'
         }
+        lambdaTestPlugin {
+            id = 'geb-lambdatest'
+            implementationClass = 'geb.gradle.lambdatest.LambdaTestPlugin'
+        }
     }
 }

--- a/integration/geb-gradle/src/main/groovy/geb/gradle/lambdatest/LambdaTestAccount.groovy
+++ b/integration/geb-gradle/src/main/groovy/geb/gradle/lambdatest/LambdaTestAccount.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package geb.gradle.lambdatest
+
+import geb.gradle.cloud.TestTaskConfigurer
+import org.gradle.api.tasks.testing.Test
+
+class LambdaTestAccount implements TestTaskConfigurer {
+    public static final String USER_ENV_VAR = "GEB_LAMBDATEST_USERNAME"
+    public static final String ACCESS_KEY_ENV_VAR = "GEB_LAMBDATEST_AUTHKEY"
+
+    String username = System.getenv("GEB_LAMBDATEST_USERNAME")
+    String accessKey = System.getenv("GEB_LAMBDATEST_AUTHKEY")
+
+    void configure(Test test) {
+        if (username) {
+            test.environment(USER_ENV_VAR, username)
+        }
+        if (accessKey) {
+            test.environment(ACCESS_KEY_ENV_VAR, accessKey)
+        }
+    }
+}

--- a/integration/geb-gradle/src/main/groovy/geb/gradle/lambdatest/LambdaTestExtension.groovy
+++ b/integration/geb-gradle/src/main/groovy/geb/gradle/lambdatest/LambdaTestExtension.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package geb.gradle.lambdatest
+
+import geb.gradle.cloud.BrowserSpec
+import geb.gradle.cloud.CloudBrowsersExtension
+import groovy.transform.InheritConstructors
+
+@InheritConstructors
+class LambdaTestExtension extends CloudBrowsersExtension {
+
+    LambdaTestAccount account
+    LambdaTestTunnelOps local
+    List<URL> applicationUrls = []
+    boolean useTunnel = true
+
+    void addExtensions() {
+        browsers = project.container(BrowserSpec) { new BrowserSpec("lambdatest", it) }
+        extensions.browsers = browsers
+        account = new LambdaTestAccount()
+        local = new LambdaTestTunnelOps()
+        extensions.create('tunnel', LambdaTestTunnel, project, project.logger, this)
+    }
+
+    void task(Closure configuration) {
+        browsers.all { BrowserSpec browser ->
+            project.tasks["${browser.displayName}Test"].configure configuration
+        }
+    }
+
+    void account(Closure configuration) {
+        project.configure(account, configuration)
+        configureTestTasksWith(account)
+    }
+
+    void tunnelOps(Closure configuration) {
+        project.configure(local, configuration)
+        configureTestTasksWith(local)
+    }
+
+    void application(String... urls) {
+        applicationUrls.addAll(urls.collect { new URL(it) })
+    }
+
+    void application(URL... urls) {
+        applicationUrls.addAll(urls)
+    }
+}

--- a/integration/geb-gradle/src/main/groovy/geb/gradle/lambdatest/LambdaTestPlugin.groovy
+++ b/integration/geb-gradle/src/main/groovy/geb/gradle/lambdatest/LambdaTestPlugin.groovy
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package geb.gradle.lambdatest
+
+import geb.gradle.lambdatest.task.DownloadLambdaTestTunnel
+import geb.gradle.cloud.BrowserSpec
+import geb.gradle.cloud.task.StartExternalTunnel
+import geb.gradle.cloud.task.StopExternalTunnel
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.Sync
+import org.gradle.api.tasks.testing.Test
+
+class LambdaTestPlugin implements Plugin<Project> {
+
+    public static final String CLOSE_TUNNEL_TASK_NAME = 'closeLambdaTestTunnel'
+    public static final String OPEN_TUNNEL_IN_BACKGROUND_TASK_NAME = 'openLambdaTestTunnelInBackground'
+    public static final String OPEN_TUNNEL_TASK_NAME = 'openLambdaTestTunnel'
+    public static final String UNZIP_TUNNEL_TASK_NAME = 'unzipLambdaTestTunnel'
+    public static final String DOWNLOAD_TUNNEL_TASK_NAME = 'downloadLambdaTestTunnel'
+    Project project
+
+    @Override
+    void apply(Project project) {
+        this.project = project
+
+        def lambdaTestExtension = project.extensions.create('lambdaTest', LambdaTestExtension, project)
+        lambdaTestExtension.addExtensions()
+
+        addTunnelTasks(lambdaTestExtension)
+        addLambdaTestTasks()
+    }
+
+    void addLambdaTestTasks() {
+        def allLambdaTestTests = project.task("allLambdaTestTests") {
+            group "LambdaTest Test"
+        }
+
+        project.lambdaTest.browsers.all { BrowserSpec browser ->
+            def testTask = project.task("${browser.displayName}Test", type: Test) { Test task ->
+                group allLambdaTestTests.group
+                task.dependsOn OPEN_TUNNEL_IN_BACKGROUND_TASK_NAME
+                allLambdaTestTests.dependsOn task
+                finalizedBy CLOSE_TUNNEL_TASK_NAME
+
+                systemProperty 'geb.build.reportsDir', project.reporting.file("$name-geb")
+
+                browser.testTask = task
+                browser.configureTestTask()
+            }
+
+            def decorateReportsTask = project.task("${browser.displayName}DecorateReports", type: Copy) {
+                from testTask.reports.junitXml.destination
+                into "${testTask.reports.junitXml.destination}-decorated"
+                filter { it.replaceAll("(testsuite|testcase) name=\"(.+?)\"", "\$1 name=\"\$2 ($browser.displayName)\"") }
+            }
+
+            testTask.finalizedBy decorateReportsTask
+        }
+    }
+
+    void addTunnelTasks(LambdaTestExtension lambdaTestExtension) {
+        def downloadLambdaTestTunnel = project.task(DOWNLOAD_TUNNEL_TASK_NAME, type: DownloadLambdaTestTunnel)
+
+        def unzipLambdaTestTunnel = project.task(UNZIP_TUNNEL_TASK_NAME, type: Sync) {
+            dependsOn downloadLambdaTestTunnel
+            into(project.file("${project.buildDir}/lambdatest/unzipped"))
+            from(project.zipTree(downloadLambdaTestTunnel.outputs.files.singleFile))
+        }
+
+        def closeLambdaTestTunnel = project.task(CLOSE_TUNNEL_TASK_NAME, type: StopExternalTunnel) {
+            tunnel = project.lambdaTest.tunnel
+            onlyIf { lambdaTestExtension.useTunnel }
+        }
+
+        def openLambdaTestTunnel = project.task(OPEN_TUNNEL_TASK_NAME, type: StartExternalTunnel) {
+            onlyIf { lambdaTestExtension.useTunnel }
+        }
+
+        def openLambdaTestTunnelInBackground = project.task(OPEN_TUNNEL_IN_BACKGROUND_TASK_NAME, type: StartExternalTunnel) {
+            inBackground = true
+            finalizedBy CLOSE_TUNNEL_TASK_NAME
+            onlyIf { lambdaTestExtension.useTunnel }
+        }
+
+        [openLambdaTestTunnel, openLambdaTestTunnelInBackground].each {
+            it.configure {
+                dependsOn UNZIP_TUNNEL_TASK_NAME
+
+                tunnel = project.lambdaTest.tunnel
+                workingDir = project.buildDir
+            }
+        }
+
+        [downloadLambdaTestTunnel, unzipLambdaTestTunnel, openLambdaTestTunnelInBackground, closeLambdaTestTunnel].each {
+            it.configure {
+                onlyIf { lambdaTestExtension.useTunnel }
+            }
+        }
+    }
+}

--- a/integration/geb-gradle/src/main/groovy/geb/gradle/lambdatest/LambdaTestTunnel.groovy
+++ b/integration/geb-gradle/src/main/groovy/geb/gradle/lambdatest/LambdaTestTunnel.groovy
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package geb.gradle.lambdatest
+
+import geb.gradle.cloud.ExternalTunnel
+
+import org.gradle.api.InvalidUserDataException
+import org.gradle.api.Project
+import org.slf4j.Logger
+
+class LambdaTestTunnel extends ExternalTunnel {
+    private static final String HTTPS_PROTOCOL = 'https'
+
+    final LambdaTestExtension extension
+
+    final String outputPrefix = 'lambdatest-tunnel'
+    final String tunnelReadyMessage = 'You can now access your local server(s) in our remote browser.'
+
+    LambdaTestTunnel(Project project, Logger logger, LambdaTestExtension extension) {
+        super(project, logger)
+        this.extension = extension
+    }
+
+    static String assembleAppSpecifier(List<URL> applicationUrls) {
+        applicationUrls.collect { "${it.host},${determinePort(it)},${it.protocol == HTTPS_PROTOCOL ? '1' : '0'}" }.join(',')
+    }
+
+    static int determinePort(URL url) {
+        url.port > 0 ? url.port : (url.protocol == HTTPS_PROTOCOL ? 443 : 80)
+    }
+
+    @Override
+    void validateState() {
+        if (!extension.account.username) {
+            def errorMsg = 'LambdaTest username not provided, Set Environment variable :' + LambdaTestAccount.USER_ENV_VAR
+            println(errorMsg)
+            throw new InvalidUserDataException(errorMsg)
+        }
+        if (!extension.account.accessKey) {
+            def errorMsg = 'LambdaTest accesskey not provided, Set Environment variable :' + LambdaTestAccount.ACCESS_KEY_ENV_VAR
+            println(errorMsg)
+            throw new InvalidUserDataException(errorMsg)
+        }
+    }
+
+    @Override
+    List<String> assembleCommandLine() {
+        def tunnelPath = project.fileTree(project.tasks.unzipLambdaTestTunnel.outputs.files.singleFile).singleFile.absolutePath
+        def commandLine = [tunnelPath]
+        commandLine << "-user" << extension.account.username
+        commandLine << "-key" << extension.account.accessKey
+        commandLine << "-v"
+        if (extension.local.tunnelName) {
+            commandLine << '-tunnelName' << extension.local.tunnelName
+        }
+        if (extension.local.config) {
+            commandLine << "-config" << assembleAppSpecifier(extension.local.config)
+        }
+        if (extension.local.controller) {
+            commandLine << "-controller" << extension.local.controller
+        }
+        if (extension.local.customSSHHost) {
+            commandLine << "-customSSHHost" << extension.local.customSSHHost
+        }
+        if (extension.local.customSSHPort) {
+            commandLine << "-customSSHPort" << extension.local.customSSHPort
+        }
+        if (extension.local.customSSHPrivateKey) {
+            commandLine << "-customSSHPrivateKey" << extension.local.customSSHPrivateKey
+        }
+        if (extension.local.customSSHUser) {
+            commandLine << "-customSSHUser" << extension.local.customSSHUser
+        }
+        if (extension.local.dir) {
+            commandLine << "-dir" << extension.local.dir
+        }
+        if (extension.local.dns) {
+            commandLine << "-dns" << extension.local.dns
+        }
+        if (extension.local.emulateChrome) {
+            commandLine << "-emulateChrome" << extension.local.emulateChrome
+        }
+        if (extension.local.env) {
+            commandLine << "-env" << extension.local.env
+        }
+        if (extension.local.infoAPIPort) {
+            commandLine << "-infoAPIPort" << extension.local.infoAPIPort
+        }
+        if (extension.local.localdomains) {
+            commandLine << "-local-domains" << extension.local.localdomains
+        }
+        if (extension.local.logFile) {
+            commandLine << "-logFile" << extension.local.logFile
+        }
+        if (extension.local.mode) {
+            commandLine << "-mode" << extension.local.mode
+        }
+        if (extension.local.nows) {
+            commandLine << "-nows" << extension.local.nows
+        }
+        if (extension.local.outputconfig) {
+            commandLine << "-output-config" << extension.local.outputconfig
+        }
+        if (extension.local.pac) {
+            commandLine << "-pac" << extension.local.pac
+        }
+        if (extension.local.pidfile) {
+            commandLine << "-pidfile" << extension.local.pidfile
+        }
+        if (extension.local.port) {
+            commandLine << "-port" << extension.local.port
+        }
+        if (extension.local.proxyhost) {
+            commandLine << "-proxy-host" << extension.local.proxyhost
+        }
+        if (extension.local.proxypass) {
+            commandLine << "-proxy-pass" << extension.local.proxypass
+        }
+        if (extension.local.proxyport) {
+            commandLine << "-proxy-port" << extension.local.proxyport
+        }
+        if (extension.local.proxyuser) {
+            commandLine << "-proxy-user" << extension.local.proxyuser
+        }
+        if (extension.local.remotedebug) {
+            commandLine << "-remote-debug" << extension.local.remotedebug
+        }
+        if (extension.local.server) {
+            commandLine << "-server" << extension.local.server
+        }
+        if (extension.local.sharedtunnel) {
+            commandLine << "-shared-tunnel"
+        }
+        if (extension.local.version) {
+            commandLine << "-version" << extension.local.version
+        }
+        commandLine
+    }
+
+    @Override
+    String getTunnelReadyMessage() {
+        "Tunnel claim successful"
+    }
+}

--- a/integration/geb-gradle/src/main/groovy/geb/gradle/lambdatest/LambdaTestTunnelOps.groovy
+++ b/integration/geb-gradle/src/main/groovy/geb/gradle/lambdatest/LambdaTestTunnelOps.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package geb.gradle.lambdatest
+
+import geb.gradle.cloud.TestTaskConfigurer
+import org.gradle.api.tasks.testing.Test
+
+class LambdaTestTunnelOps implements TestTaskConfigurer {
+
+    public static final String LOCAL_ID_ENV_VAR = "GEB_LAMBDATEST_TUNNELID"
+
+    String identifier
+    String tunnelName
+    String config
+    String controller
+    String customSSHHost
+    String customSSHPort
+    String customSSHPrivateKey
+    String customSSHUser
+    String dir
+    String dns
+    String emulateChrome
+    String env
+    String infoAPIPort
+    String localdomains
+    String logFile
+    String mode
+    String nows
+    String outputconfig
+    String pac
+    String pidfile
+    String port
+    String proxyhost
+    String proxypass
+    String proxyport
+    String proxyuser
+    String remotedebug
+    String server
+    String sharedtunnel
+    String version
+
+    List<String> additionalOptions = []
+
+    void configure(Test test) {
+        test.environment(LOCAL_ID_ENV_VAR, identifier)
+    }
+}

--- a/integration/geb-gradle/src/main/groovy/geb/gradle/lambdatest/task/DownloadLambdaTestTunnel.groovy
+++ b/integration/geb-gradle/src/main/groovy/geb/gradle/lambdatest/task/DownloadLambdaTestTunnel.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package geb.gradle.lambdatest.task
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+import org.apache.tools.ant.taskdefs.condition.Os
+
+class DownloadLambdaTestTunnel extends DefaultTask {
+
+    @OutputFile
+    File tunnelZip = project.file("${project.buildDir}/lambdatest/LambdaTestTunnel.zip")
+    String amd64 = "amd64"
+
+    @TaskAction
+    void download() {
+        tunnelZip.parentFile.mkdirs()
+        if (!tunnelZip.exists()) {
+            def url = "https://downloads.lambdatest.com/tunnel/${osSpecificUrlPart}.zip"
+            logger.info("Downloading {} to {}", url, tunnelZip)
+            tunnelZip << new URL(url).bytes
+        }
+    }
+
+    String getOsSpecificUrlPart() {
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            Os.isArch(amd64) ? "windows/64bit/LT_Windows" : "windows/32bit/LT_Windows"
+        } else if (Os.isFamily(Os.FAMILY_MAC)) {
+            Os.isArch(amd64) ? "mac/64bit/LT_Mac" : "mac/32bit/LT_Mac"
+        } else if (Os.isFamily(Os.FAMILY_UNIX)) {
+            Os.isArch(amd64) ? "linux/64bit/LT_Linux" : "linux/32bit/LT_Linux"
+        }
+    }
+}

--- a/integration/geb-gradle/src/main/resources/META-INF/gradle-plugins/geb-lambdatest.properties
+++ b/integration/geb-gradle/src/main/resources/META-INF/gradle-plugins/geb-lambdatest.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+implementation-class=geb.gradle.lambdatest.LambdaTestPlugin

--- a/integration/geb-gradle/src/test/groovy/geb/gradle/lambdatest/LambdaTestPluginSpec.groovy
+++ b/integration/geb-gradle/src/test/groovy/geb/gradle/lambdatest/LambdaTestPluginSpec.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package geb.gradle.lambdatest
+
+import geb.gradle.PluginSpec
+
+import static LambdaTestPlugin.CLOSE_TUNNEL_TASK_NAME
+import static LambdaTestPlugin.OPEN_TUNNEL_IN_BACKGROUND_TASK_NAME
+import static LambdaTestPlugin.UNZIP_TUNNEL_TASK_NAME
+import static LambdaTestPlugin.DOWNLOAD_TUNNEL_TASK_NAME
+import static org.gradle.testkit.runner.TaskOutcome.SKIPPED
+
+class LambdaTestPluginSpec extends PluginSpec {
+
+    def "tunnel related tasks are skipped if tunnel is disabled"() {
+        given:
+        buildScript """
+            plugins {
+                id 'geb-lambdatest'
+            }
+
+            lambdaTest {
+                useTunnel = false
+            }
+        """
+
+        when:
+        def buildResult = runBuild(OPEN_TUNNEL_IN_BACKGROUND_TASK_NAME)
+
+        then:
+        with(buildResult) {
+            task(":$DOWNLOAD_TUNNEL_TASK_NAME").outcome == SKIPPED
+            task(":$UNZIP_TUNNEL_TASK_NAME").outcome == SKIPPED
+            task(":$OPEN_TUNNEL_IN_BACKGROUND_TASK_NAME").outcome == SKIPPED
+            task(":$CLOSE_TUNNEL_TASK_NAME").outcome == SKIPPED
+        }
+    }
+
+}

--- a/internal/test-support/src/main/groovy/GebConfig.groovy
+++ b/internal/test-support/src/main/groovy/GebConfig.groovy
@@ -1,5 +1,6 @@
 import geb.buildadapter.BuildAdapterFactory
 import geb.driver.BrowserStackDriverFactory
+import geb.driver.LambdaTestDriverFactory
 import geb.driver.SauceLabsDriverFactory
 import org.openqa.selenium.Capabilities
 import org.openqa.selenium.chrome.ChromeOptions
@@ -81,6 +82,14 @@ if (browserStackBrowser) {
 
     if (browserStackBrowser.contains("realMobile")) {
         testHttpServerHost = findLocalIp()
+    }
+}
+
+def lambdaTestBrowser = System.getProperty("geb.lambdatest.browser")
+if (lambdaTestBrowser) {
+    setPortIndexProperty(getForkIndex(5))
+    driver = {
+        new LambdaTestDriverFactory().create(lambdaTestBrowser)
     }
 }
 

--- a/internal/test-support/src/main/resources/SpockConfig.groovy
+++ b/internal/test-support/src/main/resources/SpockConfig.groovy
@@ -10,7 +10,7 @@ import geb.test.browsers.InternetExplorer11
 import geb.test.browsers.RequiresRealBrowser
 import geb.test.browsers.Safari
 
-def cloudBrowserSpecification = System.getProperty("geb.saucelabs.browser") ?: System.getProperty("geb.browserstack.browser")
+def cloudBrowserSpecification = System.getProperty("geb.saucelabs.browser") ?: System.getProperty("geb.browserstack.browser") ?: System.getProperty("geb.lambdatest.browser")
 def dockerizedDriver = System.getProperty("geb.dockerized.driver")
 if (cloudBrowserSpecification) {
     def includes = []

--- a/module/geb-core/geb-core.gradle
+++ b/module/geb-core/geb-core.gradle
@@ -1,5 +1,6 @@
 import geb.gradle.browserstack.BrowserStackAccount
 import geb.gradle.saucelabs.SauceAccount
+import geb.gradle.lambdatest.LambdaTestAccount
 
 buildscript {
     repositories {
@@ -12,6 +13,7 @@ buildscript {
 
 apply plugin: "geb-browserstack"
 apply plugin: "geb-saucelabs"
+apply plugin: "geb-lambdatest"
 apply plugin: ratpack.gradle.RatpackBasePlugin
 
 dependencies {
@@ -33,7 +35,7 @@ test {
 }
 
 task allCrossBrowserTests {
-    dependsOn 'allSauceLabsTests', 'allBrowserStackTests', 'allLocalCrossBrowserTests'
+    dependsOn 'allSauceLabsTests', 'allBrowserStackTests', 'allLocalCrossBrowserTests','allLambdaTestTests'
 }
 
 task firefoxLinuxTest(type: Test) {
@@ -109,6 +111,31 @@ browserStack {
         identifier = UUID.randomUUID().toString()
     }
 }
+
+lambdaTest {
+    def applicationAddresses = [8000, 8080, 9000, 9090, 9999].collect { "http://localhost:$it" }
+    application(*applicationAddresses)
+
+    browsers {
+        chrome_windows_70 {
+            capabilities platform: "Windows 10"
+        }
+    }
+    task {
+        maxHeapSize = "512m"
+        testClassesDirs = test.testClassesDirs
+        classpath = test.classpath
+        maxParallelForks 5
+    }
+    account {
+        username = System.getenv(LambdaTestAccount.USER_ENV_VAR)
+        accessKey = System.getenv(LambdaTestAccount.ACCESS_KEY_ENV_VAR)
+    }
+    tunnelOps {
+        identifier = UUID.randomUUID().toString()
+    }
+}
+
 
 task nonIeBrowserStackTests {
     dependsOn 'androidTest', 'chromeMac78Test', 'chromeWindows78Test', 'firefoxWindows70Test', 'firefoxMac47Test'

--- a/module/geb-core/src/main/groovy/geb/driver/LambdaTestDriverFactory.groovy
+++ b/module/geb-core/src/main/groovy/geb/driver/LambdaTestDriverFactory.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package geb.driver
+
+import com.google.common.collect.ImmutableMap
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.remote.DesiredCapabilities
+
+class LambdaTestDriverFactory extends CloudDriverFactory {
+
+    public static final String LOCAL_IDENTIFIER_CAPABILITY = "lambdatest.localIdentifier"
+
+    @Override
+    String assembleProviderUrl(String username, String password) {
+        "https://$username:$password@hub.lambdatest.com/wd/hub"
+    }
+
+    WebDriver create(String specification, Map<String, Object> additionalCapabilities = [:]) {
+        create(specification, System.getenv("GEB_LAMBDATEST_USERNAME"), System.getenv("GEB_LAMBDATEST_AUTHKEY"), additionalCapabilities)
+    }
+
+    WebDriver create(String specification, String username, String password, String localId, Map<String, Object> capabilities = [:]) {
+        def mergedCapabilities = ImmutableMap.builder().putAll(capabilities).put(LOCAL_IDENTIFIER_CAPABILITY, localId).build()
+        create(specification, username, password, mergedCapabilities)
+    }
+    protected void configureCapabilities(DesiredCapabilities desiredCapabilities) {
+        desiredCapabilities.setCapability("tunnel", "false")
+        def tunnelId = System.getenv("GEB_LAMBDATEST_TUNNELID")
+        if (tunnelId) {
+            desiredCapabilities.setCapability(LOCAL_IDENTIFIER_CAPABILITY, tunnelId)
+        }
+    }
+}


### PR DESCRIPTION
Purpose is to Integrate LambdaTest with Geb framework

**[Module Section]**

plugin named "geb-lambdatest" added in file ~/module/geb-core/geb-core.gradle

> apply plugin: "geb-lambdatest"

and added **lambdaTest** task 

> lambdaTest {
>   def applicationAddresses = [8000, 8080, 9000, 9090, 9999].collect { "http://localhost:$it" }
>   application(*applicationAddresses)
>   ...
> }

**[Integration Section]**

 **lambdaTestPlugin** in plugins section [ file : ~/integration/geb-gradle/geb-gradle.gradlegeb-gradle.gradle]

>        lambdaTestPlugin {
>           id = 'geb-lambdatest'
>           implementationClass = 'geb.gradle.lambdatest.LambdaTestPlugin'
>        }

LambdaTestPlugin class follows the basic structure required for geb plugin integration. 
Created task's for **LambdaTest Tunnel** like, 
- downloadLambdaTestTunnel
- unzipLambdaTestTunnel
- openLambdaTestTunnelInBackground
- openLambdaTestTunnel
- closeLambdaTestTunnel

Also, created a test spec named **LambdaTestPluginSpec** [file : ~/integration/geb-gradle/src/test/groovy/geb/gradle/lambdatest/LambdaTestPluginSpec.groovy]

Tested using specific module test command
> ./gradlew :module:geb-core:check

For entire test suite and quality checks, executed
> ./gradlew check




