### PR TITLE
Update `Page Objects` url to its new location

### DIFF
--- a/doc/site/src/ratpack/templates/main.html
+++ b/doc/site/src/ratpack/templates/main.html
@@ -197,7 +197,7 @@
                         <h1 class="ui header">What is it?</h1>
                         <p>Geb is a browser automation solution.</p>
                         <p>It brings together the power of <a href="http://code.google.com/p/selenium/">WebDriver</a>, the elegance of <a href="http://jquery.com/" title="jQuery: The Write Less, Do More, JavaScript Library">jQuery</a> content selection,
-                            the robustness of <a href="http://code.google.com/p/selenium/wiki/PageObjects">Page Object</a> modelling and the expressiveness of the <a href="http://www.groovy-lang.org/">Groovy</a> language.</p>
+                            the robustness of <a href="https://github.com/SeleniumHQ/selenium/wiki/PageObjects">Page Object</a> modelling and the expressiveness of the <a href="http://www.groovy-lang.org/">Groovy</a> language.</p>
                         <p>It can be used for scripting, scraping and general automation — or equally as a functional/web/acceptance testing solution via integration with testing frameworks such as <a href="http://spockframework.org">Spock</a>,
                             <a href="http://www.junit.org/">JUnit</a> &amp; <a href="http://testng.org/">TestNG</a>.</p>
                         <p>The <a href="manual/current/">Book of Geb</a> contains all the information you need to get started with Geb.</p>


### PR DESCRIPTION
This was fixed in the docs (#151) but the main site (http://www.gebish.org) is still pointing to "code.google.com" which then redirects to an archived repo: https://github.com/seleniumhq/selenium-google-code-issue-archive