### PR TITLE
CloseTunnelWithAPI

### DIFF
--- a/doc/manual/src/docs/asciidoc/111-cloud-browsers.adoc
+++ b/doc/manual/src/docs/asciidoc/111-cloud-browsers.adoc
@@ -166,9 +166,9 @@ if (lambdaTestBrowser) {
        assert username
        def accessKey = System.getenv("GEB_LAMBDATEST_AUTHKEY")
        assert accessKey
-       def tunnelId = System.getenv("GEB_LAMBDATEST_TUNNELID")
-       assert localId
-       new LambdaTestDriverFactory().create(lambdaTestBrowser, username, accessKey, tunnelId)
+       def tunnelName = System.getenv("GEB_LAMBDATEST_TUNNELNAME")
+       assert tunnelName
+       new LambdaTestDriverFactory().create(lambdaTestBrowser, username, accessKey, tunnelName)
     }
 }
 ----

--- a/integration/geb-gradle/src/main/groovy/geb/gradle/lambdatest/LambdaTestExtension.groovy
+++ b/integration/geb-gradle/src/main/groovy/geb/gradle/lambdatest/LambdaTestExtension.groovy
@@ -30,6 +30,7 @@ class LambdaTestExtension extends CloudBrowsersExtension {
 
     LambdaTestAccount account
     LambdaTestTunnelOps local
+    List<URL> applicationUrls = []
     boolean useTunnel = true
 
     void addExtensions() {
@@ -47,5 +48,13 @@ class LambdaTestExtension extends CloudBrowsersExtension {
     void tunnelOps(Closure configuration) {
         project.configure(local, configuration)
         configureTestTasksWith(local)
+    }
+
+    void application(String... urls) {
+        applicationUrls.addAll(urls.collect { new URL(it) })
+    }
+
+    void application(URL... urls) {
+        applicationUrls.addAll(urls)
     }
 }

--- a/integration/geb-gradle/src/main/groovy/geb/gradle/lambdatest/LambdaTestPlugin.groovy
+++ b/integration/geb-gradle/src/main/groovy/geb/gradle/lambdatest/LambdaTestPlugin.groovy
@@ -16,7 +16,7 @@
 package geb.gradle.lambdatest
 
 import geb.gradle.cloud.task.StartExternalTunnel
-import geb.gradle.cloud.task.StopExternalTunnel
+import geb.gradle.lambdatest.task.StopLambdaTestTunnel
 import geb.gradle.lambdatest.task.DownloadLambdaTestTunnel
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -54,7 +54,7 @@ class LambdaTestPlugin implements Plugin<Project> {
             from(project.zipTree(downloadLambdaTestTunnel.outputs.files.singleFile))
         }
 
-        def closeLambdaTestTunnel = project.task(CLOSE_TUNNEL_TASK_NAME, type: StopExternalTunnel) {
+        def closeLambdaTestTunnel = project.task(CLOSE_TUNNEL_TASK_NAME, type: StopLambdaTestTunnel) {
             tunnel = project.lambdaTest.tunnel
             onlyIf { lambdaTestExtension.useTunnel }
         }

--- a/integration/geb-gradle/src/main/groovy/geb/gradle/lambdatest/LambdaTestTunnel.groovy
+++ b/integration/geb-gradle/src/main/groovy/geb/gradle/lambdatest/LambdaTestTunnel.groovy
@@ -22,10 +22,12 @@ import org.gradle.api.Project
 import org.slf4j.Logger
 
 class LambdaTestTunnel extends ExternalTunnel {
-    final LambdaTestExtension extension
+    static int userAPIPort
 
+    final LambdaTestExtension extension
     final String outputPrefix = 'lambdatest-tunnel'
     final String tunnelReadyMessage = 'Tunnel claim successful'
+    final String infoAPIPortKey = "-infoAPIPort"
 
     LambdaTestTunnel(Project project, Logger logger, LambdaTestExtension extension) {
         super(project, logger)
@@ -83,7 +85,11 @@ class LambdaTestTunnel extends ExternalTunnel {
             commandLine << "-env" << extension.local.env
         }
         if (extension.local.infoAPIPort) {
-            commandLine << "-infoAPIPort" << extension.local.infoAPIPort
+            commandLine << infoAPIPortKey << extension.local.infoAPIPort
+            userAPIPort = extension.local.infoAPIPort.toInteger()
+        }
+        else {
+            commandLine << infoAPIPortKey << extension.local.apiPort
         }
         if (extension.local.localdomains) {
             commandLine << "-local-domains" << extension.local.localdomains

--- a/integration/geb-gradle/src/main/groovy/geb/gradle/lambdatest/LambdaTestTunnelOps.groovy
+++ b/integration/geb-gradle/src/main/groovy/geb/gradle/lambdatest/LambdaTestTunnelOps.groovy
@@ -20,7 +20,8 @@ import org.gradle.api.tasks.testing.Test
 
 class LambdaTestTunnelOps implements TestTaskConfigurer {
 
-    public static final String LOCAL_ID_ENV_VAR = "GEB_LAMBDATEST_TUNNELID"
+    public static final String TUNNEL_NAME_ENV_VAR = "GEB_LAMBDATEST_TUNNELNAME"
+    public static int apiPort = findRandomOpenPortForLTTunnel()
 
     String tunnelName
     String config
@@ -53,7 +54,22 @@ class LambdaTestTunnelOps implements TestTaskConfigurer {
 
     List<String> additionalOptions = []
 
+    static int getAPIPort() {
+       LambdaTestTunnelOps.apiPort
+    }
+
     void configure(Test test) {
-        test.environment(LOCAL_ID_ENV_VAR, tunnelName)
+        test.environment(TUNNEL_NAME_ENV_VAR, tunnelName)
+    }
+
+    private static Integer findRandomOpenPortForLTTunnel() throws IOException {
+        try {
+            ServerSocket socket = new ServerSocket(0)
+            return socket.getLocalPort()
+        }
+        catch (Exception e)
+        {
+            System.out.println(e.printStackTrace())
+        }
     }
 }

--- a/integration/geb-gradle/src/main/groovy/geb/gradle/lambdatest/task/StopLambdaTestTunnel.groovy
+++ b/integration/geb-gradle/src/main/groovy/geb/gradle/lambdatest/task/StopLambdaTestTunnel.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package geb.gradle.lambdatest.task
+
+import geb.gradle.cloud.ExternalTunnel
+import geb.gradle.lambdatest.LambdaTestTunnel
+import geb.gradle.lambdatest.LambdaTestTunnelOps
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+class StopLambdaTestTunnel extends DefaultTask {
+
+    private static int infoAPIPort = LambdaTestTunnelOps.getAPIPort()
+    ExternalTunnel tunnel
+
+    @TaskAction
+    void stop() {
+        try {
+            // Close LambdaTest Tunnel
+            def delete
+            def hostURL = "http://127.0.0.1:"
+            def apiClosure = "/api/v1.0/stop"
+            if (LambdaTestTunnel.userAPIPort > 0) {
+                infoAPIPort = LambdaTestTunnel.userAPIPort
+            }
+            logger.info "disconnecting lambdatest tunnel having infoAPI port :" + infoAPIPort
+            delete = new URL(hostURL + infoAPIPort + apiClosure).openConnection()
+            delete.requestMethod = "DELETE"
+            delete.setRequestProperty("Content-Type", "application/json")
+            def deleteRC = delete.getResponseCode()
+            if (deleteRC != 200) {
+                logger.info "Tunnel not destroyed by API, using default destroy method"
+                tunnel.stopTunnel()
+            }
+        }
+        catch (Exception e)
+        {
+            logger.info "Error occured while closing tunnel" + e.printStackTrace()
+        }
+    }
+}

--- a/module/geb-core/geb-core.gradle
+++ b/module/geb-core/geb-core.gradle
@@ -111,6 +111,9 @@ browserStack {
 }
 
 lambdaTest {
+    def applicationAddresses = [8000, 8080, 9000, 9090, 9999].collect { "http://localhost:$it" }
+    application(*applicationAddresses)
+
     browsers {
         firefox_windows_70 {
             capabilities platform: "Windows 10"

--- a/module/geb-core/src/main/groovy/geb/driver/LambdaTestDriverFactory.groovy
+++ b/module/geb-core/src/main/groovy/geb/driver/LambdaTestDriverFactory.groovy
@@ -43,9 +43,9 @@ class LambdaTestDriverFactory extends CloudDriverFactory {
     @Override
     protected void configureCapabilities(String username, String key, DesiredCapabilities desiredCapabilities) {
         desiredCapabilities.setCapability("tunnel", "true")
-        def tunnelId = System.getenv("GEB_LAMBDATEST_TUNNELID")
-        if (tunnelId) {
-            desiredCapabilities.setCapability(LOCAL_IDENTIFIER_CAPABILITY, tunnelId)
+        def tunnelName = System.getenv("GEB_LAMBDATEST_TUNNELNAME")
+        if (tunnelName) {
+            desiredCapabilities.setCapability(LOCAL_IDENTIFIER_CAPABILITY, tunnelName)
         }
     }
 }


### PR DESCRIPTION
* Have added custom task implementation to close LambdaTest tunnel immediately using infoAPIPort. 
* Have changed few variable names for good convention such as GEB_LAMBDATEST_TUNNELID to GEB_LAMBDATEST_TUNNELNAME,  tunnelId to tunnelName, TUNNEL_ID_ENV_VAR to TUNNEL_NAME_ENV_VAR etc. 
* Added Application URL Port numbers support such as 8080, 9090 etc which we missed in previous request. 