### PR TITLE
Use specificationContext to name reports

### DIFF
--- a/module/geb-spock/src/main/groovy/geb/spock/GebReportingSpec.groovy
+++ b/module/geb-spock/src/main/groovy/geb/spock/GebReportingSpec.groovy
@@ -21,9 +21,6 @@ import spock.lang.Shared
 
 class GebReportingSpec extends GebSpec {
 
-    // Ridiculous name to avoid name clashes
-    @Rule
-    TestName gebReportingSpecTestName
     private int gebReportingPerTestCounter = 1
     @Shared
     private int gebReportingSpecTestCounter = 1
@@ -56,7 +53,7 @@ class GebReportingSpec extends GebSpec {
     }
 
     String createReportLabel(String label = "") {
-        ReporterSupport.toTestReportLabel(gebReportingSpecTestCounter, gebReportingPerTestCounter++, gebReportingSpecTestName?.methodName ?: 'fixture', label)
+        ReporterSupport.toTestReportLabel(gebReportingSpecTestCounter, gebReportingPerTestCounter++, specificationContext?.currentIteration?.name ?: 'fixture', label)
     }
 
 }


### PR DESCRIPTION
As Spock 2.0 is based on JUnit 5, `@Rule`s won't work anymore.

Using Spock's ISpecificationContext works on both current versions of
Spock, 1.3 and 2.0-M1.