### PR TITLE
Use specificationContext to name reports

### DIFF
--- a/module/geb-spock/src/main/groovy/geb/spock/GebSpec.groovy
+++ b/module/geb-spock/src/main/groovy/geb/spock/GebSpec.groovy
@@ -25,9 +25,6 @@ class GebSpec extends Specification {
 
     private final static GebTestManager TEST_MANAGER = new SpockGebTestManagerBuilder().build()
 
-    @Rule
-    TestName gebSpecTestName
-
     @Delegate(includes = ["getBrowser"])
     GebTestManager getTestManager() {
         TEST_MANAGER
@@ -38,7 +35,7 @@ class GebSpec extends Specification {
     }
 
     def setup() {
-        testManager.beforeTest(gebSpecTestName.methodName)
+        testManager.beforeTest(specificationContext?.currentIteration?.name)
     }
 
     def cleanup() {


### PR DESCRIPTION
As Spock 2.0 is based on JUnit 5, `@Rule`s won't work anymore.

Using Spock's ISpecificationContext works on both current versions of
Spock, 1.3 and 2.0-M1.