### PR TITLE
Add pronunciation hint + original meaning of "Geb"

### DIFF
--- a/doc/manual/src/docs/asciidoc/010-intro.adoc
+++ b/doc/manual/src/docs/asciidoc/010-intro.adoc
@@ -1,6 +1,6 @@
 = Introduction
 
-Geb is a developer focused tool for automating the interaction between web browsers and web content.
+Geb (pronounced "jeb" and originally a contraction of "Groovy web") is a developer focused tool for automating the interaction between web browsers and web content.
 It uses the dynamic language features of {groovy} to provide a powerful content definition DSL (for modelling content for reuse) and key concepts from {jquery} to provide a powerful content
 inspection and traversal API (for finding and interacting with content).
 


### PR DESCRIPTION
The introduction in the Boof of Geb now reads:

> Geb (pronounced "jeb" and originally a contraction of "Groovy web") is a
> developer focused tool (...)