### PR TITLE
Bump jodd core and lagarto versions

### DIFF
--- a/doc/manual/src/docs/asciidoc/140-project.adoc
+++ b/doc/manual/src/docs/asciidoc/140-project.adoc
@@ -83,6 +83,7 @@ Ideas and new features for Geb can be discussed on the link:mailto:geb-dev@googl
 * github-profile:jrodalo[José Luis Rodríguez Alonso] - Website improvements
 * github-profile:sclassen[Stephan Classen] - Doc improvements
 * github-profile:pbielicki[Przemysław Bielicki] - Removal of deprecations from the build
+* github-profile:arixmkii[Arthur Sengileyev] - Dependency updates
 
 == History
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,8 @@ guava = 'com.google.guava:guava:23.0'
 htmlUnitDriver = 'org.seleniumhq.selenium:htmlunit-driver:2.54.0'
 jetty-server = { module = 'org.eclipse.jetty:jetty-server', version.ref = 'jetty' }
 jetty-servlet = { module = 'org.eclipse.jetty:jetty-servlet', version.ref = 'jetty' }
-jodd-lagarto = 'org.jodd:jodd-lagarto:5.1.5'
+jodd-core = 'org.jodd:jodd-core:5.3.0'
+jodd-lagarto = 'org.jodd:jodd-lagarto:6.0.5'
 jsoup = 'org.jsoup:jsoup:1.11.2'
 junit-platform-launcher = 'org.junit.platform:junit-platform-launcher:1.8.1'
 junit4 = { module = 'junit:junit', version.ref = 'junit4' }

--- a/module/geb-core/geb-core.gradle
+++ b/module/geb-core/geb-core.gradle
@@ -25,6 +25,7 @@ dependencies {
     api project(":module:geb-waiting")
     api libs.threeTen.extra
 
+    implementation(libs.jodd.core)
     implementation(libs.jodd.lagarto) {
         exclude(group: "ch.qos.logback")
     }


### PR DESCRIPTION
Bumping `lagarto` because older versions depends on `jodd-log`, which depends on really narrow range of `log4j [2.8, 2.9)` and breaks some builds, where `log4j2` libraries are used.

As `lagarto` no longer depends on core, I had to add `jodd-core` dependency separately.

`jodd-core` is needed for
```groovy
import jodd.util.collection.CompositeIterator
```