### PR TITLE
Java 11 compatibility of the build

### DIFF
--- a/internal/test-support-spock/src/main/groovy/geb/test/GebSpecWithCallbackServer.groovy
+++ b/internal/test-support-spock/src/main/groovy/geb/test/GebSpecWithCallbackServer.groovy
@@ -19,7 +19,7 @@ import spock.lang.Shared
 
 class GebSpecWithCallbackServer extends GebSpecWithServer {
 
-    protected final static String JQUERY_CODE = getClass().getResource("/jquery-1.4.2.min.js").text
+    protected final static String JQUERY_CODE = CallbackHttpServer.getResource("/jquery-1.4.2.min.js").text
 
     @Shared
     CallbackHttpServer callbackServer = new CallbackHttpServer({ browser.config })

--- a/module/geb-core/src/test/groovy/geb/conf/ConfigurationDriverCreationSpec.groovy
+++ b/module/geb-core/src/test/groovy/geb/conf/ConfigurationDriverCreationSpec.groovy
@@ -26,18 +26,23 @@ import spock.lang.Specification
 class ConfigurationDriverCreationSpec extends Specification {
 
     @Shared
-    URLClassLoader originalContextClassLoader
+    ClassLoader originalContextClassLoader
 
     @Shared
-    URLClassLoader classLoader
+    ClassLoader classLoader
 
     def d
 
     def setupSpec() {
-        // We have to remove the ie driver from the classpath
-        def thisLoader = getClass().classLoader
-        def classpath = thisLoader.getURLs().findAll { !it.path.contains("selenium-ie-driver") }
-        classLoader = new URLClassLoader(classpath as URL[], thisLoader.parent)
+        // We have to suppress the ie driver on the classpath
+        classLoader = new ClassLoader(getClass().classLoader) {
+            @Override
+            protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+                name.startsWith('org.openqa.selenium.ie.') ?
+                findClass(name) :
+                super.loadClass(name, resolve)
+            }
+        }
 
         originalContextClassLoader = Thread.currentThread().contextClassLoader
         Thread.currentThread().contextClassLoader = classLoader

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.kordamp.gradle.oci-build-cache" version "0.5.0"
+    id "org.kordamp.gradle.oci-build-cache" version "0.6.0"
 }
 
 include "module",


### PR DESCRIPTION
This PR changes two things to make the build work properly when using Java 11 or newer to execute the build.

1. It updates the OCI build cache plugin to 0.6.0, as the 0.5.0 uses a version of a library that uses Java class from the standard lib that got removed with Java 11. 0.6.0 updates this library which then is Java 11+ compatible.

2. It replaces a questionable class loader hack that depended on the app class loader and also the current context class coader being `URLClassLoader`s which formerly was the case, but is not anymore with Java 11 and actually might also have been different with other Java implementations already,
with another hack that just uses a new class loader that does not delegate to the parent class loader for the packages that should not be available for the test.