### PR TITLE
Use System.nanoTime for duration measurement

### DIFF
--- a/module/geb-core/src/test/groovy/geb/BrowserNetworkLatencySpec.groovy
+++ b/module/geb-core/src/test/groovy/geb/BrowserNetworkLatencySpec.groovy
@@ -22,8 +22,6 @@ import org.openqa.selenium.UnsupportedCommandException
 
 import java.time.Duration
 
-import static java.time.Instant.now
-
 class BrowserNetworkLatencySpec extends GebSpecWithCallbackServer {
 
     def "setting network latency using htmlunit driver results in a IncorrectDriverTypeException"() {
@@ -74,10 +72,10 @@ class BrowserNetworkLatencySpec extends GebSpecWithCallbackServer {
         // end::setNetworkLatency[]
 
         when:
-        def startInstant = now()
+        def start = System.nanoTime()
         $("button").click()
         waitFor { $(".ajax-completed") }
-        def duration = Duration.between(startInstant, now())
+        def duration = Duration.ofNanos(System.nanoTime() - start)
 
         then:
         duration >= networkLatency

--- a/module/geb-waiting/src/main/groovy/geb/waiting/Wait.groovy
+++ b/module/geb-waiting/src/main/groovy/geb/waiting/Wait.groovy
@@ -15,7 +15,7 @@
  */
 package geb.waiting
 
-import java.time.Instant
+import static java.util.concurrent.TimeUnit.MILLISECONDS
 
 /**
  * Represents a particular configuration of waiting, but does not encompass what is to be waited on.
@@ -107,7 +107,7 @@ class Wait {
             thrown = e
         }
 
-        def timedOut = Instant.now() > timeoutThreshold
+        def timedOut = timeoutThreshold - System.nanoTime() <= 0
         while (!pass && !timedOut) {
             sleepForRetryInterval()
             try {
@@ -117,7 +117,7 @@ class Wait {
                 pass = new UnknownWaitForEvaluationResult(e)
                 thrown = e
             } finally {
-                timedOut = Instant.now() > timeoutThreshold
+                timedOut = timeoutThreshold - System.nanoTime() <= 0
             }
         }
 
@@ -132,8 +132,12 @@ class Wait {
         seconds * 1000L
     }
 
-    private Instant timeoutThresholdFromNow() {
-        Instant.now().plusMillis(toMilliseconds(timeout))
+    private static long toNanoseconds(Number seconds) {
+        MILLISECONDS.toNanos(toMilliseconds(seconds))
+    }
+
+    private long timeoutThresholdFromNow() {
+        System.nanoTime() + toNanoseconds(timeout)
     }
 
     /**


### PR DESCRIPTION
For measuring durations within one JVM instance, the most appropriate method is `System.nanoTime()` as it is independent of any wall clocks, DST changes and so on.