### PR TITLE
Generate automatic failure report for cleanupSpec error in correct report group

### DIFF
--- a/module/geb-junit4/src/test/groovy/geb/junit4/GebReportingTestTest.groovy
+++ b/module/geb-junit4/src/test/groovy/geb/junit4/GebReportingTestTest.groovy
@@ -69,7 +69,7 @@ class GebReportingTestTest extends GebReportingTest {
     def doTestReport() {
         if (++counter > 1) {
             def report = reportGroupDir.listFiles().find { it.name.startsWith("00" + (counter - 1)) && endsWith('end.html') }
-            assert report.exists()
+            assert report?.exists()
             assert report.text.contains('<div class="d1" id="d1">')
         }
     }

--- a/module/geb-spock/src/test/groovy/geb/spock/GebReportingSpecSpec.groovy
+++ b/module/geb-spock/src/test/groovy/geb/spock/GebReportingSpecSpec.groovy
@@ -277,7 +277,7 @@ class GebReportingSpecSpec extends Specification {
         """
 
         then:
-        new File(reportDir, "001-001-fixture-failure.html").exists()
+        reportFile("001-001-fixture-failure.html").exists()
     }
 
     SummarizedEngineExecutionResults runReportingSpec(String additionalConfiguration = "", String body) {


### PR DESCRIPTION
Currently a browser is instantiated early in `beforeTestClass` if reporting is enabled just to configure the reporting.
But if you have a mix of test that use Geb and test that don't use it, this is wasted effort.
Especially if you do more when a browser is instaniated automatically like auto-login into the SUT.

With this change the browser creator is decorated to do the additional actions,
so the browser is only created when it is actually used in the test.