### PR TITLE
Fix handling skipped invocations in the OnFailureReporter

### DIFF
--- a/module/geb-spock/src/main/groovy/geb/spock/OnFailureReporter.groovy
+++ b/module/geb-spock/src/main/groovy/geb/spock/OnFailureReporter.groovy
@@ -16,6 +16,8 @@
 package geb.spock
 
 import geb.test.ManagedGebTest
+import org.opentest4j.TestAbortedException
+import org.opentest4j.TestSkippedException
 import org.spockframework.runtime.extension.IMethodInterceptor
 import org.spockframework.runtime.extension.IMethodInvocation
 
@@ -23,6 +25,8 @@ class OnFailureReporter implements IMethodInterceptor {
     void intercept(IMethodInvocation invocation) throws Throwable {
         try {
             invocation.proceed()
+        } catch (TestAbortedException | TestSkippedException ignoredException) {
+            throw ignoredException
         } catch (Throwable throwable) {
             ManagedGebTest spec = invocation.instance
             if (spec.testManager.reportingEnabled) {


### PR DESCRIPTION
#676 [An option on how to handle skipped items in the OnFailureReporter](https://github.com/geb/issues/issues/676)