### PR TITLE
Remove end of maintenance notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-> # :warning: **Geb is no longer being maintained**
-> Personal and professional circumstances of the sole maintainer have changed leading to lack of capacity and the interest needed to keep maintaining the project.
-
 [![Build Status](https://circleci.com/gh/geb/geb/tree/master.svg?style=shield&circle-token=36ce4eb346f11ba916707d493b3f226bd5c9a5ec)](https://circleci.com/gh/geb/workflows/geb/tree/master)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.gebish/geb-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.gebish/geb-core)
 [![GitHub contributors](https://img.shields.io/github/contributors/geb/geb.svg)](https://github.com/geb/geb/graphs/contributors/)

--- a/doc/site/src/ratpack/templates/main.html
+++ b/doc/site/src/ratpack/templates/main.html
@@ -112,11 +112,6 @@
                     </div>
                 </div>
 
-                <div class="ui massive red message">
-                    <div class="header">Geb is no longer maintained!</div>
-                    <p>Personal and professional circumstances of the sole maintainer have changed leading to lack of capacity and interest needed to keep maintaining the project.</p>
-                </div>
-
                 <div class="ui inverted center aligned text container">
                     <img class="logo-header" src="/images/logo.png" alt="GEB" title='pronounced "Jeb"' />
 


### PR DESCRIPTION
Work is underway to move Geb under Groovy's Apache Software Foundation umbrella. There's no need for an end-of-maintenance notice, as we will be continuing maintenance going forward.