### PR TITLE
Introducing Geb Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Build Status](https://circleci.com/gh/geb/geb/tree/master.svg?style=shield&circle-token=36ce4eb346f11ba916707d493b3f226bd5c9a5ec)](https://circleci.com/gh/geb/workflows/geb/tree/master)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.gebish/geb-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.gebish/geb-core)
 [![GitHub contributors](https://img.shields.io/github/contributors/geb/geb.svg)](https://github.com/geb/geb/graphs/contributors/)
+[![](https://img.shields.io/badge/Gurubase-Ask%20Geb%20Guru-006BFF)](https://gurubase.io/g/geb)
 
 Geb (pronounced “jeb”) is a browser automation solution. It brings together the power of WebDriver, the elegance of jQuery content selection, the robustness of Page Object modelling and the expressiveness of the Groovy language.
 


### PR DESCRIPTION
Hello Geb team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Geb Guru](https://gurubase.io/g/geb) to Gurubase. Geb Guru uses the data from this repo and data from the [docs](https://www.gebish.org/manual/current/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Geb Guru" badge, which highlights that Geb now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Geb Guru in Gurubase, just let me know that's totally fine.