### PR TITLE
Update Java for Heroku

### DIFF
--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=11


### PR DESCRIPTION
This change sets the JDK version for running the Heroku build, as it still uses 8 by default and we are now upgraded to 11. According to the error output and the Heroku docs this file with the single property is all that is needed, but I am not able to test it as publishing to Heroku only happens on builds of the master branch and requires secrets to be injected. 